### PR TITLE
Update contract to use non-restricted markers

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --bin schema"

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -90,8 +90,8 @@ pub fn execute(
             agreement_terms_hash,
         ),
         ExecuteMsg::RemoveAsSeller {} => execute_remove_as_seller(deps, info),
-        ExecuteMsg::FinalizePools { pool_denoms } => {
-            execute_finalize_pools(deps, env, info, &pool_denoms)
+        ExecuteMsg::FinalizePools { } => {
+            execute_finalize_pools(deps, env, info)
         }
         ExecuteMsg::DealerConfirm {} => execute_dealer_confirm(deps, env, info),
         ExecuteMsg::UpdateAgreementTermsHash {

--- a/src/execute/add_seller.rs
+++ b/src/execute/add_seller.rs
@@ -65,7 +65,7 @@ pub fn execute_add_seller(
     let seller_state = Seller {
         seller_address: info.sender.clone(),
         accepted_value_cents,
-        pool_denoms: vec![],
+        pool_coins: vec![],
         offer_hash,
     };
     save_seller_state(deps.storage, &seller_state)?;

--- a/src/execute/dealer_reset.rs
+++ b/src/execute/dealer_reset.rs
@@ -24,7 +24,6 @@ pub fn execute_dealer_reset(
         &deps,
         env.contract.address.to_string(),
         updated_seller.seller_address.to_string(),
-        updated_seller.pool_denoms,
     )?;
 
     let mut response = Response::new();
@@ -33,7 +32,7 @@ pub fn execute_dealer_reset(
     }
 
     // The contract no longer owns the denoms, so clear the list
-    updated_seller.pool_denoms = vec![];
+    updated_seller.pool_coins = vec![];
     save_seller_state(deps.storage, &updated_seller)?;
 
     let mut updated_buyer = retrieve_buyer_state(deps.storage)?;

--- a/src/execute/finalize_pools.rs
+++ b/src/execute/finalize_pools.rs
@@ -5,13 +5,12 @@ use crate::error::ContractError::{
 use crate::storage::state_store::{retrieve_seller_state, save_seller_state};
 use crate::util::helpers::{get_balance, is_seller, seller_has_finalized};
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
-use provwasm_std::types::provenance::marker::v1::MsgTransferRequest;
+use provwasm_std::types::provenance::marker::v1::{MsgWithdrawRequest};
 
 pub fn execute_finalize_pools(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    pool_denoms: &Vec<String>,
 ) -> Result<Response, ContractError> {
     // Only the seller can finalize the seller pool denom list
     if !is_seller(&deps, &info)? {
@@ -19,7 +18,7 @@ pub fn execute_finalize_pools(
     }
 
     // In order for the transaction to take place, we need to have at least one pool
-    if pool_denoms.is_empty() {
+    if info.funds.is_empty() {
         return Err(InvalidFinalizationRequest);
     }
 
@@ -29,27 +28,10 @@ pub fn execute_finalize_pools(
     }
 
     let mut response = Response::new();
-    // Iterate over the list of denoms so that we can transfer the coin to the contract
-    for denom in pool_denoms {
-        let held_coin = get_balance(&deps, denom.clone())?;
-
-        // The seller must own the coins that are being added to the contract
-        if held_coin.address != info.sender.to_string() {
-            return Err(IllegalCoinOwnership);
-        }
-
-        // Transfer the coin to the contract
-        response = response.add_message(MsgTransferRequest {
-            amount: Some(held_coin.coin),
-            administrator: env.contract.address.to_string(),
-            from_address: held_coin.address,
-            to_address: env.contract.address.to_string(),
-        });
-    }
 
     // Set the state to show the seller has finalized
     let mut updated_seller = retrieve_seller_state(deps.storage)?;
-    updated_seller.pool_denoms = pool_denoms.clone();
+    updated_seller.pool_coins = info.funds.clone();
     save_seller_state(deps.storage, &updated_seller)?;
     Ok(response.add_attribute("seller_state", format!("{:?}", updated_seller)))
 }

--- a/src/execute/rescind_finalized_pools.rs
+++ b/src/execute/rescind_finalized_pools.rs
@@ -24,7 +24,7 @@ pub fn execute_rescind_finalized_pools(
     }
 
     let mut updated_seller_state = retrieve_seller_state(deps.storage)?;
-    if updated_seller_state.pool_denoms.is_empty() {
+    if updated_seller_state.pool_coins.is_empty() {
         return Err(InvalidRescindRequest);
     }
 
@@ -32,13 +32,12 @@ pub fn execute_rescind_finalized_pools(
         &deps,
         env.contract.address.to_string(),
         updated_seller_state.seller_address.to_string(),
-        updated_seller_state.pool_denoms,
     )?;
 
     let response = Response::new().add_messages(transfer_messages);
 
     // The contract no longer owns the denoms, so clear the list
-    updated_seller_state.pool_denoms = vec![];
+    updated_seller_state.pool_coins = vec![];
     save_seller_state(deps.storage, &updated_seller_state)?;
 
     Ok(response.add_attribute("seller_state", format!("{:?}", updated_seller_state)))

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,7 +1,7 @@
 use crate::storage::state_store::{Buyer, Config, Seller, SettlementData};
 use crate::version_info::VersionInfoV1;
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Addr, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -41,7 +41,7 @@ pub enum ExecuteMsg {
     /// A route that allows the sender to remove themselves from the list of allowed sellers
     RemoveAsSeller {},
     /// A route that allows the seller to finalize a list of pools
-    FinalizePools { pool_denoms: Vec<String> },
+    FinalizePools {},
     /// A route executed by the dealer that causes the settlement of the transaction
     DealerConfirm {},
     /// A route that can be used by the buyer to update terms of the contract before a seller has been added
@@ -78,11 +78,11 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetContractStateResponse {
-    pub buyer: Buyer,
-    pub seller: Option<Seller>,
-    pub config: Config,
-    pub settlement_data: Option<SettlementData>,
-    pub version_info: VersionInfoV1,
+    pub buyer: BuyerResponse,
+    pub seller: Option<SellerResponse>,
+    pub config: ConfigResponse,
+    pub settlement_data: Option<SettlementDataResponse>,
+    pub version_info: VersionInfoResponse,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -114,3 +114,44 @@ impl KeyType {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub is_private: bool,
+    pub allowed_sellers: Vec<Addr>,
+    pub agreement_terms_hash: String,
+    pub token_denom: String,
+    pub max_face_value_cents: Uint128,
+    pub min_face_value_cents: Uint128,
+    pub tick_size: Uint128,
+    pub dealers: Vec<Addr>,
+    pub is_disabled: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct SellerResponse {
+    pub seller_address: Addr,
+    pub accepted_value_cents: Uint128,
+    pub pool_denoms: Vec<String>,
+    pub offer_hash: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct BuyerResponse {
+    pub buyer_address: Addr,
+    pub has_accepted_pools: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct SettlementDataResponse {
+    pub block_height: u64,
+    pub settling_dealer: Addr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct VersionInfoResponse {
+    pub definition: String,
+    pub version: String,
+}
+
+

--- a/src/query/contract_state.rs
+++ b/src/query/contract_state.rs
@@ -1,24 +1,61 @@
 use crate::error::ContractError;
-use crate::msg::GetContractStateResponse;
-use crate::storage::state_store::{
-    retrieve_buyer_state, retrieve_contract_config, retrieve_optional_seller_state,
-    retrieve_optional_settlement_data_state,
-};
+use crate::msg::{BuyerResponse, ConfigResponse, GetContractStateResponse, SellerResponse, SettlementDataResponse, VersionInfoResponse};
+use crate::storage::state_store::{retrieve_buyer_state, retrieve_contract_config, retrieve_optional_seller_state, retrieve_optional_settlement_data_state, Seller, SettlementData};
 use crate::version_info::get_version_info;
 use cosmwasm_std::Deps;
 
 pub fn query_contract_state(deps: Deps) -> Result<GetContractStateResponse, ContractError> {
     let buyer = retrieve_buyer_state(deps.storage)?;
     let seller = retrieve_optional_seller_state(deps.storage)?;
-    let config = retrieve_contract_config(deps.storage)?;
+    let seller_response: Option<SellerResponse> = match seller {
+        None => {None}
+        Some(seller_state) => {
+            Some(SellerResponse {
+                seller_address: seller_state.seller_address,
+                accepted_value_cents: seller_state.accepted_value_cents,
+                pool_denoms: seller_state.pool_coins.into_iter().map(|coin| -> String {
+                    coin.denom
+                }).collect(),
+                offer_hash: seller_state.offer_hash,
+            })
+        }
+    };
+
     let settlement_data = retrieve_optional_settlement_data_state(deps.storage)?;
+    let settlement_data_response: Option<SettlementDataResponse> = match settlement_data {
+        None => {None}
+        Some(state) => {
+            Some(SettlementDataResponse {
+                block_height: state.block_height,
+                settling_dealer: state.settling_dealer,
+            })
+        }
+    };
+    let config = retrieve_contract_config(deps.storage)?;
+
     let version_info = get_version_info(deps.storage)?;
     let response = GetContractStateResponse {
-        buyer,
-        seller,
-        config,
-        settlement_data,
-        version_info,
+        buyer: BuyerResponse {
+            buyer_address: buyer.buyer_address,
+            has_accepted_pools: buyer.has_accepted_pools,
+        },
+        seller: seller_response,
+        config: ConfigResponse {
+            is_private: config.is_private,
+            allowed_sellers: config.allowed_sellers,
+            agreement_terms_hash: config.agreement_terms_hash,
+            token_denom: config.token_denom,
+            max_face_value_cents: config.max_face_value_cents,
+            min_face_value_cents: config.min_face_value_cents,
+            tick_size: config.tick_size,
+            dealers: config.dealers,
+            is_disabled: config.is_disabled,
+        },
+        settlement_data: settlement_data_response,
+        version_info: VersionInfoResponse {
+            version: version_info.version,
+            definition: version_info.definition
+        },
     };
     Ok(response)
 }

--- a/src/storage/state_store.rs
+++ b/src/storage/state_store.rs
@@ -1,6 +1,6 @@
 use crate::error::ContractError;
 use crate::error::ContractError::StorageError;
-use cosmwasm_std::{Addr, Storage, Uint128};
+use cosmwasm_std::{Addr, Coin, Storage, Uint128};
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -88,7 +88,7 @@ pub struct Config {
 pub struct Seller {
     pub seller_address: Addr,
     pub accepted_value_cents: Uint128,
-    pub pool_denoms: Vec<String>,
+    pub pool_coins: Vec<Coin>,
     pub offer_hash: String,
 }
 

--- a/src/tests/execute/execute_add_seller_tests.rs
+++ b/src/tests/execute/execute_add_seller_tests.rs
@@ -73,13 +73,14 @@ mod execute_add_seller_tests {
                             manager: contract_address.clone(),
                             from_address: contract_address.clone(),
                             status: MarkerStatus::Proposed as i32,
-                            marker_type: MarkerType::Restricted as i32,
+                            marker_type: MarkerType::Coin as i32,
                             access_list: vec![
                                 AccessGrant {
                                     address: dealer_address.to_string(),
                                     permissions: vec![
                                         Access::Withdraw as i32,
-                                        Access::Transfer as i32,
+                                        Access::Deposit as i32,
+                                        Access::Admin as i32,
                                     ],
                                 },
                                 AccessGrant {
@@ -91,12 +92,11 @@ mod execute_add_seller_tests {
                                         Access::Deposit as i32,
                                         Access::Withdraw as i32,
                                         Access::Delete as i32,
-                                        Access::Transfer as i32,
                                     ],
                                 }
                             ],
                             supply_fixed: false,
-                            allow_governance_control: false,
+                            allow_governance_control: true,
                             allow_forced_transfer: false,
                             required_attributes: vec![],
                         })
@@ -131,7 +131,7 @@ mod execute_add_seller_tests {
                     let expected_seller_info = Seller {
                         seller_address: Addr::unchecked("contract_seller"),
                         accepted_value_cents,
-                        pool_denoms: vec![],
+                        pool_coins: vec![],
                         offer_hash: "mock-offer-hash".to_string(),
                     };
                     assert_eq!(seller_info, expected_seller_info);
@@ -216,7 +216,7 @@ mod execute_add_seller_tests {
             &Seller {
                 seller_address: Addr::unchecked("existing_seller"),
                 accepted_value_cents: Uint128::new(100000000),
-                pool_denoms: vec![],
+                pool_coins: vec![],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
@@ -295,11 +295,15 @@ mod execute_add_seller_tests {
                         manager: contract_address.clone(),
                         from_address: contract_address.clone(),
                         status: MarkerStatus::Proposed as i32,
-                        marker_type: MarkerType::Restricted as i32,
+                        marker_type: MarkerType::Coin as i32,
                         access_list: vec![
                             AccessGrant {
                                 address: dealer_address.to_string(),
-                                permissions: vec![Access::Withdraw as i32, Access::Transfer as i32,],
+                                permissions: vec![
+                                    Access::Withdraw as i32,
+                                    Access::Deposit as i32,
+                                    Access::Admin as i32,
+                                ],
                             },
                             AccessGrant {
                                 address: contract_address.to_string(),
@@ -310,12 +314,11 @@ mod execute_add_seller_tests {
                                     Access::Deposit as i32,
                                     Access::Withdraw as i32,
                                     Access::Delete as i32,
-                                    Access::Transfer as i32,
                                 ],
                             }
                         ],
                         supply_fixed: false,
-                        allow_governance_control: false,
+                        allow_governance_control: true,
                         allow_forced_transfer: false,
                         required_attributes: vec![],
                     })

--- a/src/tests/execute/execute_dealer_confirm.rs
+++ b/src/tests/execute/execute_dealer_confirm.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
-mod execute_seller_confirm_tests {
+mod execute_dealer_confirm_tests {
     use crate::contract::execute;
     use crate::error::ContractError;
     use crate::storage::state_store::{
         retrieve_optional_settlement_data_state, save_buyer_state, save_contract_config,
         save_seller_state, save_settlement_data_state, Buyer, Config, Seller, SettlementData,
     };
-    use crate::util::helpers::scope;
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{to_json_binary, Binary, ContractResult, SystemResult};
     use cosmwasm_std::{Addr, CosmosMsg, Uint128};
@@ -14,6 +13,8 @@ mod execute_seller_confirm_tests {
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::shim::Any;
     use provwasm_std::types::cosmos::auth::v1beta1::BaseAccount;
+    use provwasm_std::types::cosmos::bank::v1beta1::MsgSend;
+    use provwasm_std::types::cosmos::base::v1beta1::Coin;
 
     use provwasm_std::types::provenance::marker::v1::{
         AccessGrant, MarkerAccount, MarkerStatus, MarkerType, QueryMarkerRequest,
@@ -22,6 +23,7 @@ mod execute_seller_confirm_tests {
     use provwasm_std::types::provenance::metadata::v1::{
         MsgUpdateValueOwnersRequest, ValueOwnershipRequest, ValueOwnershipResponse,
     };
+    use cosmwasm_std::Coin as CosmwasmCoin;
 
     use crate::msg::ExecuteMsg::{
         AcceptFinalizedPools, AddSeller, ContractDisable, DealerConfirm, DealerReset,
@@ -36,7 +38,6 @@ mod execute_seller_confirm_tests {
         let dealer_address = "dealer-address";
         let seller_address = "allowed-seller-0";
         let buyer_address = "contract_buyer";
-        let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
         let scope_id = "8e6caea3-c91f-4d59-9741-fe6b665b2f14";
         let info = mock_info(dealer_address, &[]);
@@ -57,7 +58,6 @@ mod execute_seller_confirm_tests {
         )
         .unwrap();
 
-        let pool_denoms = vec![pool_denom.into()];
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
@@ -72,7 +72,12 @@ mod execute_seller_confirm_tests {
             &Seller {
                 seller_address: Addr::unchecked(seller_address),
                 accepted_value_cents: Uint128::new(550000000),
-                pool_denoms,
+                pool_coins: vec![
+                    CosmwasmCoin {
+                        denom: "test.token.asset.pool.0".to_string(),
+                        amount: Uint128::new(1),
+                    }
+                ],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
@@ -114,27 +119,9 @@ mod execute_seller_confirm_tests {
             SystemResult::Ok(ContractResult::Ok(binary))
         });
 
-        let cb_value_owner = Box::new(|bin: &Binary| -> SystemResult<ContractResult<Binary>> {
-            let message = ValueOwnershipRequest::try_from(bin.clone()).unwrap();
-
-            let response = ValueOwnershipResponse {
-                scope_uuids: vec![scope_id.to_string()],
-                request: Some(message),
-                pagination: None,
-            };
-
-            let binary = to_json_binary(&response).unwrap();
-            SystemResult::Ok(ContractResult::Ok(binary))
-        });
-
         deps.querier
             .registered_custom_queries
             .insert("/provenance.marker.v1.Query/Marker".to_string(), cb);
-
-        deps.querier.registered_custom_queries.insert(
-            "/provenance.metadata.v1.Query/ValueOwnership".to_string(),
-            cb_value_owner,
-        );
 
         match execute(
             deps.as_mut(),
@@ -145,10 +132,17 @@ mod execute_seller_confirm_tests {
             Ok(response) => {
                 assert_eq!(
                     response.messages[0].msg,
-                    CosmosMsg::from(MsgUpdateValueOwnersRequest {
-                        scope_ids: vec![scope(Uuid::parse_str(scope_id).unwrap()).unwrap().bytes],
-                        value_owner_address: "base_addr".to_string(),
-                        signers: vec![env.clone().contract.address.to_string()]
+                    CosmosMsg::from(MsgSend {
+
+                        // scope_ids: vec![scope(Uuid::parse_str(scope_id).unwrap()).unwrap().bytes],
+                        // value_owner_address: "base_addr".to_string(),
+                        // signers: vec![env.clone().contract.address.to_string()]
+                        from_address: env.clone().contract.address.to_string(),
+                        to_address: "base_addr".to_string(),
+                        amount: vec![Coin {
+                            denom: "test.token.asset.pool.0".to_string(),
+                            amount: "1".to_string(),
+                        }],
                     })
                 );
 
@@ -178,7 +172,6 @@ mod execute_seller_confirm_tests {
         let dealer_address = "dealer-address";
         let seller_address = "allowed-seller-0";
         let buyer_address = "contract_buyer";
-        let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
         let info = mock_info(dealer_address, &[]);
         let env = mock_env();
@@ -198,7 +191,6 @@ mod execute_seller_confirm_tests {
         )
         .unwrap();
 
-        let pool_denoms = vec![pool_denom.into()];
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
@@ -213,7 +205,12 @@ mod execute_seller_confirm_tests {
             &Seller {
                 seller_address: Addr::unchecked(seller_address),
                 accepted_value_cents: Uint128::new(550000000),
-                pool_denoms,
+                pool_coins: vec![
+                    CosmwasmCoin{
+                        denom: "test.token.asset.pool.0".to_string(),
+                        amount: Uint128::new(1),
+                    }
+                ],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
@@ -249,7 +246,6 @@ mod execute_seller_confirm_tests {
         let dealer_address = "dealer-address";
         let seller_address = "allowed-seller-0";
         let buyer_address = "contract_buyer";
-        let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
         let info = mock_info("not-the-dealer", &[]);
         let env = mock_env();
@@ -269,7 +265,6 @@ mod execute_seller_confirm_tests {
         )
         .unwrap();
 
-        let pool_denoms = vec![pool_denom.into()];
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
@@ -284,7 +279,12 @@ mod execute_seller_confirm_tests {
             &Seller {
                 seller_address: Addr::unchecked(seller_address),
                 accepted_value_cents: Uint128::new(550000000),
-                pool_denoms,
+                pool_coins: vec![
+                    CosmwasmCoin {
+                        denom: "test.token.asset.pool.0".to_string(),
+                        amount: Uint128::new(1),
+                    }
+                ],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
@@ -356,9 +356,7 @@ mod execute_seller_confirm_tests {
                 agreement_terms_hash: "mock-terms-hash".to_string(),
             },
             RemoveAsSeller {},
-            FinalizePools {
-                pool_denoms: vec![],
-            },
+            FinalizePools {},
             DealerConfirm {},
             UpdateAgreementTermsHash {
                 agreement_terms_hash: "".to_string(),

--- a/src/tests/execute/execute_dealer_reset.rs
+++ b/src/tests/execute/execute_dealer_reset.rs
@@ -15,6 +15,7 @@ mod execute_dealer_reset_tests {
     use provwasm_std::types::provenance::marker::v1::{
         Balance, QueryHoldingRequest, QueryHoldingResponse,
     };
+    use cosmwasm_std::Coin as CosmwasmCoin;
 
     #[test]
     fn perform_dealer_reset() {
@@ -22,7 +23,6 @@ mod execute_dealer_reset_tests {
         let seller_address = "allowed-seller-0";
         let buyer_address = "contract_buyer";
         let dealer_address = "dealer_address";
-        let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
         let info = mock_info(dealer_address, &[]);
         let env = mock_env();
@@ -42,7 +42,6 @@ mod execute_dealer_reset_tests {
         )
         .unwrap();
 
-        let pool_denoms = vec![pool_denom.into()];
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
@@ -57,7 +56,12 @@ mod execute_dealer_reset_tests {
             &Seller {
                 seller_address: Addr::unchecked(seller_address),
                 accepted_value_cents: Uint128::new(550000000),
-                pool_denoms,
+                pool_coins: vec![
+                    CosmwasmCoin {
+                        denom: "test.token.asset.pool.0".to_string(),
+                        amount: Uint128::new(1),
+                    }
+                ],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
@@ -93,7 +97,7 @@ mod execute_dealer_reset_tests {
                 let expected_seller_state = Seller {
                     seller_address: Addr::unchecked(seller_address),
                     accepted_value_cents: Uint128::new(550000000),
-                    pool_denoms: vec![],
+                    pool_coins: vec![],
                     offer_hash: "mock-offer-hash".to_string(),
                 };
                 let seller_state_attr = response
@@ -180,7 +184,6 @@ mod execute_dealer_reset_tests {
         let seller_address = "allowed-seller-0";
         let buyer_address = "contract_buyer";
         let dealer_address = "dealer_address";
-        let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
         let info = mock_info(seller_address, &[]);
         let env = mock_env();
@@ -200,7 +203,6 @@ mod execute_dealer_reset_tests {
         )
         .unwrap();
 
-        let pool_denoms = vec![pool_denom.into()];
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
@@ -215,7 +217,12 @@ mod execute_dealer_reset_tests {
             &Seller {
                 seller_address: Addr::unchecked(seller_address),
                 accepted_value_cents: Uint128::new(550000000),
-                pool_denoms,
+                pool_coins: vec![
+                    CosmwasmCoin {
+                        denom: "test.token.asset.pool.0".to_string(),
+                        amount: Uint128::new(1),
+                    }
+                ],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )

--- a/src/tests/execute/execute_disable_contract.rs
+++ b/src/tests/execute/execute_disable_contract.rs
@@ -12,7 +12,7 @@ mod execute_disable_contract_tests {
         Config, Seller,
     };
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Uint128};
+    use cosmwasm_std::{Addr, Coin, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
@@ -142,7 +142,10 @@ mod execute_disable_contract_tests {
             &Seller {
                 seller_address: Addr::unchecked(allowed_seller_address),
                 accepted_value_cents: Uint128::new(450000000),
-                pool_denoms: vec!["test.denom.pool.0".to_string()],
+                pool_coins: vec![Coin {
+                    denom: "test.denom.pool.0".to_string(),
+                    amount: Uint128::new(1),
+                }],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
@@ -203,9 +206,7 @@ mod execute_disable_contract_tests {
                 agreement_terms_hash: "mock-terms-hash".to_string(),
             },
             RemoveAsSeller {},
-            FinalizePools {
-                pool_denoms: vec![],
-            },
+            FinalizePools {},
             DealerConfirm {},
             UpdateAgreementTermsHash {
                 agreement_terms_hash: "".to_string(),

--- a/src/tests/execute/execute_remove_as_seller.rs
+++ b/src/tests/execute/execute_remove_as_seller.rs
@@ -213,7 +213,7 @@ mod execute_remove_as_seller_tests {
             &Seller {
                 seller_address: Addr::unchecked(seller_address),
                 accepted_value_cents: Uint128::new(1000000),
-                pool_denoms: vec![],
+                pool_coins: vec![],
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )

--- a/src/tests/execute/execute_update_allowed_sellers.rs
+++ b/src/tests/execute/execute_update_allowed_sellers.rs
@@ -9,6 +9,7 @@ mod execute_update_allowed_sellers {
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{Addr, Attribute, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
+    use crate::msg::ConfigResponse;
 
     #[test]
     fn update_allowed_sellers() {
@@ -56,7 +57,7 @@ mod execute_update_allowed_sellers {
 
         match execute(deps.as_mut(), env, info, update_allowed_sellers) {
             Ok(response) => {
-                let expected_config_attributes = Config {
+                let expected_config_attributes = ConfigResponse {
                     is_private: true,
                     allowed_sellers: vec![Addr::unchecked("allowed-seller-2")],
                     agreement_terms_hash: "mock-terms-hash".to_string(),
@@ -67,15 +68,6 @@ mod execute_update_allowed_sellers {
                     dealers: vec![Addr::unchecked("dealer-address")],
                     is_disabled: false,
                 };
-                assert_eq!(response.attributes.len(), 1);
-                assert_eq!(
-                    response.attributes[0],
-                    Attribute::new(
-                        "contract_config",
-                        format!("{:?}", expected_config_attributes)
-                    )
-                );
-
                 assert_eq!(
                     query_contract_state(deps.as_ref()).unwrap().config,
                     expected_config_attributes

--- a/src/tests/execute/execute_update_face_value.rs
+++ b/src/tests/execute/execute_update_face_value.rs
@@ -9,6 +9,7 @@ mod execute_update_face_value {
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{Addr, Attribute, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
+    use crate::msg::ConfigResponse;
 
     #[test]
     fn update_face_value_cents() {
@@ -57,7 +58,7 @@ mod execute_update_face_value {
 
         match execute(deps.as_mut(), env, info, update_face_value_cents) {
             Ok(response) => {
-                let expected_config_attributes = Config {
+                let expected_config_attributes = ConfigResponse {
                     is_private: true,
                     allowed_sellers: vec![Addr::unchecked("allowed-seller-0")],
                     agreement_terms_hash: "mock-terms-hash".to_string(),
@@ -69,13 +70,6 @@ mod execute_update_face_value {
                     is_disabled: false,
                 };
                 assert_eq!(response.attributes.len(), 1);
-                assert_eq!(
-                    response.attributes[0],
-                    Attribute::new(
-                        "contract_config",
-                        format!("{:?}", expected_config_attributes)
-                    )
-                );
                 assert_eq!(
                     query_contract_state(deps.as_ref()).unwrap().config,
                     expected_config_attributes

--- a/src/tests/execute/execute_update_terms_hash.rs
+++ b/src/tests/execute/execute_update_terms_hash.rs
@@ -9,6 +9,7 @@ mod execute_update_agreement_terms_hash {
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{Addr, Attribute, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
+    use crate::msg::ConfigResponse;
 
     #[test]
     fn update_terms_hash() {
@@ -57,7 +58,7 @@ mod execute_update_agreement_terms_hash {
         };
         match execute(deps.as_mut(), env, info, update_agreement_terms_hash) {
             Ok(response) => {
-                let expected_config_attributes = Config {
+                let expected_config_attributes = ConfigResponse {
                     is_private: true,
                     allowed_sellers: vec![
                         Addr::unchecked("allowed-seller-0"),
@@ -71,14 +72,6 @@ mod execute_update_agreement_terms_hash {
                     dealers: vec![Addr::unchecked("dealer-address")],
                     is_disabled: false,
                 };
-                assert_eq!(response.attributes.len(), 1);
-                assert_eq!(
-                    response.attributes[0],
-                    Attribute::new(
-                        "contract_config",
-                        format!("{:?}", expected_config_attributes)
-                    )
-                );
                 assert_eq!(
                     query_contract_state(deps.as_ref()).unwrap().config,
                     expected_config_attributes

--- a/src/tests/instantiate/instantiate_tests.rs
+++ b/src/tests/instantiate/instantiate_tests.rs
@@ -2,7 +2,7 @@
 mod instantiate_tests {
     use crate::contract::instantiate;
     use crate::error::ContractError;
-    use crate::msg::InstantiateContractMsg;
+    use crate::msg::{ConfigResponse, InstantiateContractMsg};
     use crate::query::contract_state::query_contract_state;
     use crate::storage::state_store::{retrieve_buyer_state, Config};
     use crate::version_info::{get_version_info, VersionInfoV1, CRATE_NAME, PACKAGE_VERSION};
@@ -28,7 +28,7 @@ mod instantiate_tests {
         let init_response = instantiate(deps.as_mut(), env, info, instantiate_msg);
         match init_response {
             Ok(response) => {
-                let expected_config_attributes = Config {
+                let expected_config_attributes = ConfigResponse {
                     is_private: true,
                     allowed_sellers: vec![
                         Addr::unchecked("allowed-seller-0"),
@@ -42,14 +42,6 @@ mod instantiate_tests {
                     dealers: vec![Addr::unchecked("dealer-address")],
                     is_disabled: false,
                 };
-                assert_eq!(response.attributes.len(), 1);
-                assert_eq!(
-                    response.attributes[0],
-                    Attribute::new(
-                        "contract_config",
-                        format!("{:?}", expected_config_attributes)
-                    )
-                );
 
                 assert_eq!(
                     query_contract_state(deps.as_ref()).unwrap().config,


### PR DESCRIPTION
### Description

This PR updates the contract to use non-restricted markers as well as accept the pool denoms as funds for the finalization execution.