### PR TITLE
Upgrade contract to be compatible with Provenance v1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+ "rayon",
+]
 
 [[package]]
 name = "arrayvec"
@@ -50,16 +189,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitvec"
@@ -75,15 +220,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -93,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "borsh"
@@ -144,12 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,33 +313,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "cosmwasm-crypto"
-version = "1.5.3"
+name = "cosmwasm-core"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
+checksum = "8d075f6bb1483a6ce83b5cbc73a3a1207e0316ac1e34ed1f2a4d9fc3a0f07bf6"
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ced5a6dd2801a383d3e14e5ae5caa7fdfeff1bd9f22b30e810e0aded8a5869"
 dependencies = [
- "digest 0.10.7",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "cosmwasm-core",
+ "digest",
  "ecdsa",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.4",
+ "num-traits",
+ "p256",
+ "rand_core",
+ "rayon",
+ "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
+checksum = "35bd1873f84d9b17edf8a90ffe10a89a649b82feacc00e36788b81d2c3cbf03c"
 dependencies = [
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e3a2136e2a60e8b6582f5dffca5d1a683ed77bf38537d330bc1dfccd69010"
+checksum = "27984b137eb2ac561f97f6bdb02004a98eb6f2ba263062c140b8e231ee1826b7"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -220,33 +367,34 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d803bea6bd9ed61bd1ee0b4a2eb09ee20dbb539cc6e0b8795614d20952ebb1"
+checksum = "f4ef0d201f611bdb6c9124207032423eb956f1fc8ab3e3ee7253a9c08a5f5809"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
+checksum = "2522fb5c9a0409712bb1d036128bccf3564e6b2ac82f942ae4cf3c8df3e26fa8"
 dependencies = [
- "base64",
- "bech32",
+ "base64 0.22.1",
+ "bech32 0.11.0",
  "bnum",
+ "cosmwasm-core",
  "cosmwasm-crypto",
  "cosmwasm-derive",
- "derivative",
- "forward_ref",
+ "derive_more",
  "hex",
+ "rand_core",
  "schemars",
  "serde",
  "serde-json-wasm",
- "sha2 0.10.8",
+ "sha2",
  "static_assertions",
  "thiserror",
 ]
@@ -261,13 +409,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -284,22 +457,36 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "cw-storage-plus"
-version = "1.2.0"
+name = "curve25519-dalek-derive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13360e9007f51998d42b1bc6b7fa0141f74feae61ed5fd1e5b0a89eec7b5de1"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -308,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.1.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
+checksum = "b04852cd38f044c0751259d5f78255d07590d136b8a86d4e09efdd7666bd6d27"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -343,12 +530,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.9.0"
+name = "derive_more"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
 dependencies = [
- "generic-array",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -357,7 +556,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -376,25 +575,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek",
- "hashbrown 0.12.3",
+ "ed25519",
+ "hashbrown 0.14.3",
  "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.9.9",
+ "rand_core",
+ "sha2",
  "zeroize",
 ]
 
@@ -412,12 +619,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -435,36 +641,36 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "forward_market_contract"
 version = "0.1.1"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
  "hex",
- "prost",
+ "prost 0.11.9",
  "provwasm-mocks",
  "provwasm-std",
  "rust_decimal",
  "schemars",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
  "uuid",
 ]
-
-[[package]]
-name = "forward_ref"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "funty"
@@ -501,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -511,7 +717,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -519,6 +734,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -538,7 +757,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -577,16 +796,14 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2 0.10.8",
- "signature",
+ "sha2",
 ]
 
 [[package]]
@@ -600,6 +817,25 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -617,26 +853,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
+name = "p256"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -672,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -686,45 +933,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
 ]
 
 [[package]]
 name = "provwasm-common"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938fe0a8914598b5aa201221ce2d9c5388412e348ea312bcba36b5077376b96d"
 dependencies = [
  "cosmwasm-std",
 ]
 
 [[package]]
 name = "provwasm-mocks"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1143b9d41f537559d30a3cbbcbaa3a196f829fc298daaa4bbacd5ca90309950"
+version = "2.3.0"
 dependencies = [
  "cosmwasm-std",
  "provwasm-common",
@@ -735,27 +987,25 @@ dependencies = [
 
 [[package]]
 name = "provwasm-proc-macro"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d3d936fc7e0fac992a454ec731aeded01166a894719d9161f261fc713ce251"
+version = "0.1.2"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
+ "prost-types",
+ "provwasm-common",
  "quote",
- "syn 2.0.52",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "provwasm-std"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1be9fcaa463174e3bec59a179ed5b3590aa038f0e9c68d5132bc19df212383"
+version = "2.3.0"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "cosmwasm-schema",
  "cosmwasm-std",
- "prost",
+ "prost 0.12.6",
  "prost-types",
  "provwasm-common",
  "provwasm-proc-macro",
@@ -808,7 +1058,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -818,14 +1068,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -834,6 +1078,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -901,6 +1165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +1224,6 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -982,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
+checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
 dependencies = [
  "serde",
 ]
@@ -1024,26 +1296,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1052,8 +1311,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1063,16 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,15 +1329,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1202,6 +1451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,7 +1496,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,8 +969,9 @@ dependencies = [
 
 [[package]]
 name = "provwasm-common"
-version = "0.1.0"
-source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64b62100d22d0d1725330b8822d31bd63bb92eb044fc5606b8a7b3e14837ee8"
 dependencies = [
  "cosmwasm-std",
 ]
@@ -978,7 +979,8 @@ dependencies = [
 [[package]]
 name = "provwasm-mocks"
 version = "2.3.0"
-source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7d48d2a4ac41401e81145df5e95e208f949a5ded894146b783f775ef3d1a30"
 dependencies = [
  "cosmwasm-std",
  "provwasm-common",
@@ -990,7 +992,8 @@ dependencies = [
 [[package]]
 name = "provwasm-proc-macro"
 version = "0.1.2"
-source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eced1494a23e220b86475b58cf74e9f3ddb9dce2ee686662abe83bd07855f08"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -1003,7 +1006,8 @@ dependencies = [
 [[package]]
 name = "provwasm-std"
 version = "2.3.0"
-source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3934ce53a63366af277c28f753302dda811eefeea61e7e5f0e95a3248b831ef"
 dependencies = [
  "base64 0.21.7",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "forward_market_contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bech32 0.9.1",
  "cosmwasm-schema",
@@ -970,6 +970,7 @@ dependencies = [
 [[package]]
 name = "provwasm-common"
 version = "0.1.0"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "cosmwasm-std",
 ]
@@ -977,6 +978,7 @@ dependencies = [
 [[package]]
 name = "provwasm-mocks"
 version = "2.3.0"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "cosmwasm-std",
  "provwasm-common",
@@ -988,6 +990,7 @@ dependencies = [
 [[package]]
 name = "provwasm-proc-macro"
 version = "0.1.2"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -1000,6 +1003,7 @@ dependencies = [
 [[package]]
 name = "provwasm-std"
 version = "2.3.0"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "base64 0.21.7",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_market_contract"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jordon Tolotti <jtolotti@figure.com>"]
 edition = "2021"
 
@@ -37,7 +37,7 @@ cw2 = "2.0.0"
 schemars = "0.8.15"
 serde = { version = "1.0.189", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.49" }
-provwasm-std = { path = "/Users/jordontolotti/repos/provwasm/packages/provwasm-std", version = "2.3.0-rc1"}
+provwasm-std = { git = "https://github.com/provenance-io/provwasm", tag = "v2.3.0-rc1" }
 sha2 = "0.10.8"
 hex = "0.4.3"
 bech32 = "0.9.1"
@@ -46,5 +46,5 @@ uuid = { version = "1.7.0", features = ["v1"] }
 
 
 [dev-dependencies]
-provwasm-mocks = { path = "/Users/jordontolotti/repos/provwasm/packages/provwasm-mocks", version = "=2.3.0" }
+provwasm-mocks = { git = "https://github.com/provenance-io/provwasm", tag = "v2.3.0-rc1" }
 prost = { version = "=0.11.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cw2 = "2.0.0"
 schemars = "0.8.15"
 serde = { version = "1.0.189", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.49" }
-provwasm-std = { git = "https://github.com/provenance-io/provwasm", tag = "v2.3.0-rc1" }
+provwasm-std = { version = "=2.3.0" }
 sha2 = "0.10.8"
 hex = "0.4.3"
 bech32 = "0.9.1"
@@ -46,5 +46,5 @@ uuid = { version = "1.7.0", features = ["v1"] }
 
 
 [dev-dependencies]
-provwasm-mocks = { git = "https://github.com/provenance-io/provwasm", tag = "v2.3.0-rc1" }
+provwasm-mocks = { version = "=2.3.0" }
 prost = { version = "=0.11.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ incremental = false
 overflow-checks = true
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
@@ -32,20 +30,21 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-schema = "1.2.8"
-cosmwasm-std = { version = "1.2.5", features = ["stargate"]}
-cw-storage-plus = "1.1.0"
-cw2 = "1.0.0"
+cosmwasm-schema = "2.1.0"
+cosmwasm-std = { version = "2.1.0"}
+cw-storage-plus = "2.0.0"
+cw2 = "2.0.0"
 schemars = "0.8.15"
 serde = { version = "1.0.189", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.49" }
-provwasm-std = { version = "=2.1.0"}
+provwasm-std = { path = "/Users/jordontolotti/repos/provwasm/packages/provwasm-std", version = "2.3.0-rc1"}
 sha2 = "0.10.8"
 hex = "0.4.3"
 bech32 = "0.9.1"
 rust_decimal = "1.29.0"
 uuid = { version = "1.7.0", features = ["v1"] }
 
+
 [dev-dependencies]
-provwasm-mocks = { version = "=2.1.0" }
+provwasm-mocks = { path = "/Users/jordontolotti/repos/provwasm/packages/provwasm-mocks", version = "=2.3.0" }
 prost = { version = "=0.11.9", default-features = false }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -16,7 +16,8 @@ use crate::execute::update_allowed_sellers::execute_update_allowed_sellers;
 use crate::execute::update_face_value_cents::execute_update_face_value_cents;
 use crate::execute::update_terms_hash::execute_update_terms_hash;
 use crate::instantiate::instantiate_contract::instantiate_contract;
-use crate::msg::{ExecuteMsg, InstantiateContractMsg, QueryMsg};
+use crate::migrate::migrate::migrate_contract;
+use crate::msg::{ExecuteMsg, InstantiateContractMsg, QueryMsg, MigrateMsg};
 use crate::query::contract_state::query_contract_state;
 use crate::storage::state_store::{
     retrieve_contract_config, retrieve_optional_settlement_data_state,
@@ -136,3 +137,22 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::GetContractState {} => Ok(to_json_binary(&query_contract_state(deps)?)?),
     }
 }
+
+/// The entry point used when the contract admin migrates an existing instance of this contract to
+/// a new stored code instance on chain.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `env` An environment object provided by the cosmwasm framework.  Describes the contract's
+/// details, as well as blockchain information at the time of the transaction.
+/// * `msg` A custom migration message defined by this contract that will map the desired operation
+/// to the proper contract logic.
+#[entry_point]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    match msg {
+        MigrateMsg::ContractUpgrade {} => migrate_contract(deps),
+    }
+}
+

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -17,7 +17,7 @@ use crate::execute::update_face_value_cents::execute_update_face_value_cents;
 use crate::execute::update_terms_hash::execute_update_terms_hash;
 use crate::instantiate::instantiate_contract::instantiate_contract;
 use crate::migrate::migrate::migrate_contract;
-use crate::msg::{ExecuteMsg, InstantiateContractMsg, QueryMsg, MigrateMsg};
+use crate::msg::{ExecuteMsg, InstantiateContractMsg, MigrateMsg, QueryMsg};
 use crate::query::contract_state::query_contract_state;
 use crate::storage::state_store::{
     retrieve_contract_config, retrieve_optional_settlement_data_state,
@@ -155,4 +155,3 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
         MigrateMsg::ContractUpgrade {} => migrate_contract(deps),
     }
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -174,4 +174,8 @@ pub enum ContractError {
     /// Occurs if the seller is agreeing to a terms hash that does not match the latest
     #[error("The agreement terms hash provided by the seller does not match the current agreement terms hash")]
     InvalidAgreementTermsHash,
+
+    /// Occurs when a migration is attempted for an unsupported version
+    #[error("Migration does not support {version:?} version")]
+    IllegalMigrationVersion {version: String}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -177,5 +177,5 @@ pub enum ContractError {
 
     /// Occurs when a migration is attempted for an unsupported version
     #[error("Migration does not support {version:?} version")]
-    IllegalMigrationVersion {version: String}
+    IllegalMigrationVersion { version: String },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,4 @@ pub mod tests;
 // Utility methods that give access to shared logic
 pub mod util;
 pub mod version_info;
+mod migrate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,6 @@ mod storage;
 // Defines the tests for the contract
 pub mod tests;
 // Utility methods that give access to shared logic
+mod migrate;
 pub mod util;
 pub mod version_info;
-mod migrate;

--- a/src/migrate/migrate.rs
+++ b/src/migrate/migrate.rs
@@ -1,0 +1,25 @@
+use cosmwasm_std::{DepsMut, Response};
+use crate::error::ContractError;
+use crate::error::ContractError::IllegalMigrationVersion;
+use crate::version_info::{PACKAGE_VERSION, get_version_info, set_version_info, VersionInfoV1};
+
+pub fn migrate_contract(deps: DepsMut) -> Result<Response, ContractError> {
+    let current_version_info = get_version_info(deps.storage)?;
+    validate_migration(current_version_info.version)?;
+    set_version_info(deps.storage, &VersionInfoV1 {
+        definition: current_version_info.definition,
+        version: PACKAGE_VERSION.to_string(),
+    })?;
+    Ok(
+        Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute("new_version", PACKAGE_VERSION.to_string())
+    )
+}
+
+fn validate_migration(current_version: String) -> Result<(), ContractError>  {
+    if current_version != "0.1.1" {
+        return Err(IllegalMigrationVersion { version: current_version})
+    }
+    Ok(())
+}

--- a/src/migrate/migrate.rs
+++ b/src/migrate/migrate.rs
@@ -1,25 +1,28 @@
-use cosmwasm_std::{DepsMut, Response};
 use crate::error::ContractError;
 use crate::error::ContractError::IllegalMigrationVersion;
-use crate::version_info::{PACKAGE_VERSION, get_version_info, set_version_info, VersionInfoV1};
+use crate::version_info::{get_version_info, set_version_info, VersionInfoV1, PACKAGE_VERSION};
+use cosmwasm_std::{DepsMut, Response};
 
 pub fn migrate_contract(deps: DepsMut) -> Result<Response, ContractError> {
     let current_version_info = get_version_info(deps.storage)?;
     validate_migration(current_version_info.version)?;
-    set_version_info(deps.storage, &VersionInfoV1 {
-        definition: current_version_info.definition,
-        version: PACKAGE_VERSION.to_string(),
-    })?;
-    Ok(
-        Response::new()
+    set_version_info(
+        deps.storage,
+        &VersionInfoV1 {
+            definition: current_version_info.definition,
+            version: PACKAGE_VERSION.to_string(),
+        },
+    )?;
+    Ok(Response::new()
         .add_attribute("action", "migrate")
-        .add_attribute("new_version", PACKAGE_VERSION.to_string())
-    )
+        .add_attribute("new_version", PACKAGE_VERSION.to_string()))
 }
 
-fn validate_migration(current_version: String) -> Result<(), ContractError>  {
+fn validate_migration(current_version: String) -> Result<(), ContractError> {
     if current_version != "0.1.1" {
-        return Err(IllegalMigrationVersion { version: current_version})
+        return Err(IllegalMigrationVersion {
+            version: current_version,
+        });
     }
     Ok(())
 }

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -1,0 +1,1 @@
+pub mod migrate;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -76,6 +76,15 @@ pub enum QueryMsg {
     GetContractState {},
 }
 
+/// All defined payloads to be used when migrating to a new instance of this contract.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrateMsg {
+    /// The standard migration route that modifies the [contract state](crate::store::contract_state::ContractStateV1)
+    /// to include the new values defined in a target code instance.
+    ContractUpgrade {},
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetContractStateResponse {
     pub buyer: Buyer,

--- a/src/tests/execute/execute_add_seller_tests.rs
+++ b/src/tests/execute/execute_add_seller_tests.rs
@@ -7,7 +7,7 @@ mod execute_add_seller_tests {
         retrieve_seller_state, save_buyer_state, save_contract_config, save_seller_state, Buyer,
         Config, Seller,
     };
-    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{Addr, Attribute, CosmosMsg, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::types::cosmos::base::v1beta1::Coin;
@@ -159,7 +159,10 @@ mod execute_add_seller_tests {
     #[test]
     fn add_seller_with_invalid_accepted_value() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract_seller", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make("contract-seller"),
+            funds: vec![],
+        };
         let env = mock_env();
         let add_seller_msg = AddSeller {
             accepted_value_cents: Uint128::new(900000000),
@@ -312,10 +315,7 @@ mod execute_add_seller_tests {
                         access_list: vec![
                             AccessGrant {
                                 address: dealer_address.clone().to_string(),
-                                permissions: vec![
-                                    Access::Withdraw as i32,
-                                    Access::Deposit as i32,
-                                ],
+                                permissions: vec![Access::Withdraw as i32, Access::Deposit as i32,],
                             },
                             AccessGrant {
                                 address: contract_address.to_string(),
@@ -375,7 +375,10 @@ mod execute_add_seller_tests {
     #[test]
     fn add_invalid_seller_to_private_forward_market() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("private-seller-0", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make("private-seller-0"),
+            funds: vec![],
+        };
         let env = mock_env();
         let add_seller_msg = AddSeller {
             accepted_value_cents: Uint128::new(100000000),
@@ -393,7 +396,7 @@ mod execute_add_seller_tests {
                 max_face_value_cents: Uint128::new(500000000),
                 min_face_value_cents: Uint128::new(300000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -417,7 +420,11 @@ mod execute_add_seller_tests {
     #[test]
     fn add_seller_with_invalid_agreement_hash() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("private-seller-0", &[]);
+        let seller_address = deps.api.addr_make("private-seller-0");
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         let add_seller_msg = AddSeller {
             accepted_value_cents: Uint128::new(400000000),
@@ -429,13 +436,13 @@ mod execute_add_seller_tests {
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked("private-seller-0")],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "hash-B".to_string(),
                 token_denom: "test.forward.market.token".into(),
                 max_face_value_cents: Uint128::new(500000000),
                 min_face_value_cents: Uint128::new(300000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )

--- a/src/tests/execute/execute_dealer_confirm.rs
+++ b/src/tests/execute/execute_dealer_confirm.rs
@@ -6,8 +6,8 @@ mod execute_dealer_confirm_tests {
         retrieve_optional_settlement_data_state, save_buyer_state, save_contract_config,
         save_seller_state, save_settlement_data_state, Buyer, Config, Seller, SettlementData,
     };
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{to_json_binary, Binary, ContractResult, SystemResult, MessageInfo};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{to_json_binary, Binary, ContractResult, MessageInfo, SystemResult};
     use cosmwasm_std::{Addr, CosmosMsg, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::shim::Any;
@@ -305,12 +305,7 @@ mod execute_dealer_confirm_tests {
             },
         )
         .unwrap();
-        match execute(
-            deps.as_mut(),
-            env.clone(),
-            info,
-            DealerConfirm {},
-        ) {
+        match execute(deps.as_mut(), env.clone(), info, DealerConfirm {}) {
             Ok(_) => {
                 panic!(
                     "failed to return an error when an unauthorized seller attempted to confirm the contract"
@@ -331,7 +326,10 @@ mod execute_dealer_confirm_tests {
     fn disallow_all_executions_after_settlement() {
         let mut deps = mock_provenance_dependencies();
         let dealer_address = deps.api.addr_make("dealer-address");
-        let info = mock_info("", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make(""),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,

--- a/src/tests/execute/execute_dealer_confirm.rs
+++ b/src/tests/execute/execute_dealer_confirm.rs
@@ -7,9 +7,8 @@ mod execute_dealer_confirm_tests {
         save_seller_state, save_settlement_data_state, Buyer, Config, Seller, SettlementData,
     };
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{to_json_binary, Binary, ContractResult, SystemResult};
+    use cosmwasm_std::{to_json_binary, Binary, ContractResult, SystemResult, MessageInfo};
     use cosmwasm_std::{Addr, CosmosMsg, Uint128};
-    use prost::Message;
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::shim::Any;
     use provwasm_std::types::cosmos::auth::v1beta1::BaseAccount;
@@ -29,24 +28,27 @@ mod execute_dealer_confirm_tests {
     #[test]
     fn execute_dealer_confirm() {
         let mut deps = mock_provenance_dependencies();
-        let dealer_address = "dealer-address";
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
-        let info = mock_info(dealer_address, &[]);
+        let info = MessageInfo {
+            sender: dealer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(100000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked(dealer_address)],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
             },
         )
@@ -65,7 +67,7 @@ mod execute_dealer_confirm_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(550000000),
                 pool_denoms,
                 offer_hash: "mock-offer-hash".to_string(),
@@ -75,10 +77,10 @@ mod execute_dealer_confirm_tests {
 
         let cb = Box::new(|bin: &Binary| -> SystemResult<ContractResult<Binary>> {
             let message = QueryMarkerRequest::try_from(bin.clone()).unwrap();
-
+            let inner_deps = mock_provenance_dependencies();
             let expected_marker = MarkerAccount {
                 base_account: Some(BaseAccount {
-                    address: "base_addr".to_string(),
+                    address: inner_deps.api.addr_make("base_addr").to_string(),
                     pub_key: None,
                     account_number: 1,
                     sequence: 0,
@@ -101,7 +103,7 @@ mod execute_dealer_confirm_tests {
             let response = QueryMarkerResponse {
                 marker: Some(Any {
                     type_url: "/provenance.marker.v1.MarkerAccount".to_string(),
-                    value: expected_marker.encode_to_vec(),
+                    value: expected_marker.to_proto_bytes(),
                 }),
             };
 
@@ -110,12 +112,13 @@ mod execute_dealer_confirm_tests {
         });
 
         let cb_holding = Box::new(|bin: &Binary| -> SystemResult<ContractResult<Binary>> {
+            let inner_deps = mock_provenance_dependencies();
             let message = QueryHoldingRequest::try_from(bin.clone()).unwrap();
 
             let response = if message.id == "test.token.asset.pool.0" {
                 QueryHoldingResponse {
                     balances: vec![Balance {
-                        address: seller_address.to_string(),
+                        address: inner_deps.api.addr_make("seller_address").to_string(),
                         coins: vec![Coin {
                             denom: "test.token.asset.pool.0".to_string(),
                             amount: "1".to_string(),
@@ -155,13 +158,13 @@ mod execute_dealer_confirm_tests {
                         }),
                         administrator: env.contract.address.to_string(),
                         from_address: env.contract.address.to_string(),
-                        to_address: "base_addr".to_string(),
+                        to_address: deps.api.addr_make("base_addr").to_string(),
                     })
                 );
 
                 let expected_settlement_data = SettlementData {
                     block_height: 12345,
-                    settling_dealer: Addr::unchecked(dealer_address),
+                    settling_dealer: dealer_address.clone(),
                 };
                 assert_eq!(
                     expected_settlement_data,
@@ -182,12 +185,15 @@ mod execute_dealer_confirm_tests {
     #[test]
     fn execute_seller_confirm_invalid_seller_state() {
         let mut deps = mock_provenance_dependencies();
-        let dealer_address = "dealer-address";
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
-        let info = mock_info(dealer_address, &[]);
+        let info = MessageInfo {
+            sender: dealer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
@@ -199,7 +205,7 @@ mod execute_dealer_confirm_tests {
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(100000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked(dealer_address)],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
             },
         )
@@ -209,7 +215,7 @@ mod execute_dealer_confirm_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: true,
             },
         )
@@ -218,7 +224,7 @@ mod execute_dealer_confirm_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(550000000),
                 pool_denoms,
                 offer_hash: "mock-offer-hash".to_string(),
@@ -251,14 +257,17 @@ mod execute_dealer_confirm_tests {
     }
 
     #[test]
-    fn execute_seller_confirm_unauthorized_seller() {
+    fn execute_seller_confirm_unauthorized_dealer() {
         let mut deps = mock_provenance_dependencies();
-        let dealer_address = "dealer-address";
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
-        let info = mock_info("not-the-dealer", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make("not-the-dealer"),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
@@ -270,7 +279,7 @@ mod execute_dealer_confirm_tests {
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(100000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked(dealer_address)],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
             },
         )
@@ -280,7 +289,7 @@ mod execute_dealer_confirm_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: true,
             },
         )
@@ -289,7 +298,7 @@ mod execute_dealer_confirm_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(550000000),
                 pool_denoms,
                 offer_hash: "mock-offer-hash".to_string(),
@@ -300,7 +309,7 @@ mod execute_dealer_confirm_tests {
             deps.as_mut(),
             env.clone(),
             info,
-            crate::msg::ExecuteMsg::DealerConfirm {},
+            DealerConfirm {},
         ) {
             Ok(_) => {
                 panic!(
@@ -321,6 +330,7 @@ mod execute_dealer_confirm_tests {
     #[test]
     fn disallow_all_executions_after_settlement() {
         let mut deps = mock_provenance_dependencies();
+        let dealer_address = deps.api.addr_make("dealer-address");
         let info = mock_info("", &[]);
         let env = mock_env();
         save_contract_config(
@@ -333,7 +343,7 @@ mod execute_dealer_confirm_tests {
                 max_face_value_cents: Uint128::new(550000000),
                 min_face_value_cents: Uint128::new(550000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![dealer_address],
                 is_disabled: false,
             },
         )
@@ -341,7 +351,7 @@ mod execute_dealer_confirm_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked("buyer-address"),
+                buyer_address: deps.api.addr_make("buyer-address"),
                 has_accepted_pools: false,
             },
         )
@@ -350,7 +360,7 @@ mod execute_dealer_confirm_tests {
             &mut deps.storage,
             &SettlementData {
                 block_height: 1,
-                settling_dealer: Addr::unchecked("dealer-address"),
+                settling_dealer: deps.api.addr_make("dealer-address"),
             },
         )
         .unwrap();

--- a/src/tests/execute/execute_dealer_reset.rs
+++ b/src/tests/execute/execute_dealer_reset.rs
@@ -6,8 +6,10 @@ mod execute_dealer_reset_tests {
     use crate::storage::state_store::{
         save_buyer_state, save_contract_config, save_seller_state, Buyer, Config, Seller,
     };
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{to_json_binary, Addr, Attribute, Binary, ContractResult, SystemResult, Uint128, MessageInfo};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{
+        to_json_binary, Addr, Attribute, Binary, ContractResult, MessageInfo, SystemResult, Uint128,
+    };
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::types::cosmos::base::v1beta1::Coin;
     use provwasm_std::types::provenance::marker::v1::{

--- a/src/tests/execute/execute_disable_contract.rs
+++ b/src/tests/execute/execute_disable_contract.rs
@@ -11,8 +11,8 @@ mod execute_disable_contract_tests {
         retrieve_contract_config, save_buyer_state, save_contract_config, save_seller_state, Buyer,
         Config, Seller,
     };
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, MessageInfo, Uint128};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
@@ -179,7 +179,10 @@ mod execute_disable_contract_tests {
     #[test]
     fn disallow_all_executions_when_disabled() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make(""),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,

--- a/src/tests/execute/execute_disable_contract.rs
+++ b/src/tests/execute/execute_disable_contract.rs
@@ -12,26 +12,29 @@ mod execute_disable_contract_tests {
         Config, Seller,
     };
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Uint128};
+    use cosmwasm_std::{Addr, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
     fn execute_disable_contract() {
         let mut deps = mock_provenance_dependencies();
-        let allowed_seller_address = "allowed-seller";
-        let buyer_address = "buyer-address";
+        let allowed_seller_address = deps.api.addr_make("allowed-seller");
+        let buyer_address = deps.api.addr_make("buyer-address");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(buyer_address, &[]);
+        let info = MessageInfo {
+            sender: buyer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         let config = Config {
             is_private: true,
-            allowed_sellers: vec![Addr::unchecked(allowed_seller_address)],
+            allowed_sellers: vec![allowed_seller_address.clone()],
             agreement_terms_hash: "mock-terms-hash".to_string(),
             token_denom: token_denom.into(),
             max_face_value_cents: Uint128::new(550000000),
             min_face_value_cents: Uint128::new(550000000),
             tick_size: Uint128::new(1000),
-            dealers: vec![Addr::unchecked("dealer-address")],
+            dealers: vec![deps.api.addr_make("dealer-address")],
             is_disabled: false,
         };
         save_contract_config(&mut deps.storage, &config).unwrap();
@@ -39,7 +42,7 @@ mod execute_disable_contract_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -61,20 +64,23 @@ mod execute_disable_contract_tests {
     #[test]
     fn execute_disable_contract_unauthorized() {
         let mut deps = mock_provenance_dependencies();
-        let allowed_seller_address = "allowed-seller";
-        let buyer_address = "buyer-address";
+        let allowed_seller_address = deps.api.addr_make("allowed-seller");
+        let buyer_address = deps.api.addr_make("buyer-address");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(allowed_seller_address, &[]);
+        let info = MessageInfo {
+            sender: allowed_seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         let config = Config {
             is_private: true,
-            allowed_sellers: vec![Addr::unchecked(allowed_seller_address)],
+            allowed_sellers: vec![allowed_seller_address.clone()],
             agreement_terms_hash: "mock-terms-hash".to_string(),
             token_denom: token_denom.into(),
             max_face_value_cents: Uint128::new(550000000),
             min_face_value_cents: Uint128::new(550000000),
             tick_size: Uint128::new(1000),
-            dealers: vec![Addr::unchecked("dealer-address")],
+            dealers: vec![deps.api.addr_make("dealer-address")],
             is_disabled: false,
         };
         save_contract_config(&mut deps.storage, &config).unwrap();
@@ -82,7 +88,7 @@ mod execute_disable_contract_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -110,20 +116,23 @@ mod execute_disable_contract_tests {
     #[test]
     fn execute_disable_contract_seller_already_finalized() {
         let mut deps = mock_provenance_dependencies();
-        let allowed_seller_address = "allowed-seller";
-        let buyer_address = "buyer-address";
+        let allowed_seller_address = deps.api.addr_make("allowed-seller");
+        let buyer_address = deps.api.addr_make("buyer-address");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(buyer_address, &[]);
+        let info = MessageInfo {
+            sender: buyer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         let config = Config {
             is_private: true,
-            allowed_sellers: vec![Addr::unchecked(allowed_seller_address)],
+            allowed_sellers: vec![allowed_seller_address.clone()],
             agreement_terms_hash: "mock-terms-hash".to_string(),
             token_denom: token_denom.into(),
             max_face_value_cents: Uint128::new(550000000),
             min_face_value_cents: Uint128::new(350000000),
             tick_size: Uint128::new(1000),
-            dealers: vec![Addr::unchecked("dealer-address")],
+            dealers: vec![deps.api.addr_make("dealer-address")],
             is_disabled: false,
         };
         save_contract_config(&mut deps.storage, &config).unwrap();
@@ -131,7 +140,7 @@ mod execute_disable_contract_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -140,7 +149,7 @@ mod execute_disable_contract_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(allowed_seller_address),
+                seller_address: allowed_seller_address.clone(),
                 accepted_value_cents: Uint128::new(450000000),
                 pool_denoms: vec!["test.denom.pool.0".to_string()],
                 offer_hash: "mock-offer-hash".to_string(),
@@ -182,7 +191,7 @@ mod execute_disable_contract_tests {
                 max_face_value_cents: Uint128::new(550000000),
                 min_face_value_cents: Uint128::new(550000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: true,
             },
         )
@@ -190,7 +199,7 @@ mod execute_disable_contract_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked("buyer-address"),
+                buyer_address: deps.api.addr_make("buyer-address"),
                 has_accepted_pools: false,
             },
         )

--- a/src/tests/execute/execute_finalize_pools.rs
+++ b/src/tests/execute/execute_finalize_pools.rs
@@ -5,9 +5,7 @@ mod execute_finalize_pools_tests {
     use crate::msg::ExecuteMsg::FinalizePools;
     use crate::storage::state_store::{save_contract_config, save_seller_state, Config, Seller};
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{
-        to_json_binary, Addr, Attribute, Binary, ContractResult, SystemResult, Uint128,
-    };
+    use cosmwasm_std::{to_json_binary, Addr, Attribute, Binary, ContractResult, SystemResult, Uint128, MessageInfo};
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::types::cosmos::base::v1beta1::Coin;
     use provwasm_std::types::provenance::marker::v1::{
@@ -17,22 +15,25 @@ mod execute_finalize_pools_tests {
     #[test]
     fn execute_finalize_pool() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
+        let seller_address = deps.api.addr_make("allowed-seller-0");
         let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
-        let info = mock_info(seller_address, &[]);
+        let info = MessageInfo {
+            sender:seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(350000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -42,7 +43,7 @@ mod execute_finalize_pools_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(650000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),
@@ -54,9 +55,10 @@ mod execute_finalize_pools_tests {
             let message = QueryHoldingRequest::try_from(bin.clone()).unwrap();
 
             let response = if message.id == "test.token.asset.pool.0" {
+                let inner_deps = mock_provenance_dependencies();
                 QueryHoldingResponse {
                     balances: vec![Balance {
-                        address: seller_address.to_string(),
+                        address: inner_deps.api.addr_make("allowed-seller-0").to_string(),
                         coins: vec![Coin {
                             denom: "test.token.asset.pool.0".to_string(),
                             amount: "2".to_string(),
@@ -83,7 +85,7 @@ mod execute_finalize_pools_tests {
         ) {
             Ok(response) => {
                 let expected_seller_state = Seller {
-                    seller_address: Addr::unchecked(seller_address),
+                    seller_address: seller_address.clone(),
                     accepted_value_cents: Uint128::new(650000000),
                     pool_denoms: vec![pool_denom.into()],
                     offer_hash: "mock-offer-hash".to_string(),
@@ -103,22 +105,25 @@ mod execute_finalize_pools_tests {
     #[test]
     fn execute_finalize_pool_invalid_list() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
+        let seller_address = deps.api.addr_make("allowed-seller-0");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(seller_address, &[]);
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
 
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(450000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -127,7 +132,7 @@ mod execute_finalize_pools_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(650000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),
@@ -161,22 +166,25 @@ mod execute_finalize_pools_tests {
     #[test]
     fn execute_finalize_pool_not_seller() {
         let mut deps = mock_provenance_dependencies();
-        let unauthorized_seller_address = "unauthorized-seller";
-        let allowed_seller_address = "allowed-seller";
+        let unauthorized_seller_address = deps.api.addr_make("unauthorized-seller");
+        let allowed_seller_address = deps.api.addr_make("allowed-seller");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(unauthorized_seller_address, &[]);
+        let info = MessageInfo {
+            sender: unauthorized_seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked(allowed_seller_address)],
+                allowed_sellers: vec![allowed_seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(550000000),
                 min_face_value_cents: Uint128::new(550000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -185,7 +193,7 @@ mod execute_finalize_pools_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(allowed_seller_address),
+                seller_address: allowed_seller_address.clone(),
                 accepted_value_cents: Uint128::new(650000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),

--- a/src/tests/execute/execute_finalize_pools.rs
+++ b/src/tests/execute/execute_finalize_pools.rs
@@ -4,8 +4,10 @@ mod execute_finalize_pools_tests {
     use crate::error::ContractError;
     use crate::msg::ExecuteMsg::FinalizePools;
     use crate::storage::state_store::{save_contract_config, save_seller_state, Config, Seller};
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{to_json_binary, Addr, Attribute, Binary, ContractResult, SystemResult, Uint128, MessageInfo};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{
+        to_json_binary, Attribute, Binary, ContractResult, MessageInfo, SystemResult, Uint128,
+    };
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::types::cosmos::base::v1beta1::Coin;
     use provwasm_std::types::provenance::marker::v1::{
@@ -19,7 +21,7 @@ mod execute_finalize_pools_tests {
         let pool_denom = "test.token.asset.pool.0";
         let token_denom = "test.forward.market.token";
         let info = MessageInfo {
-            sender:seller_address.clone(),
+            sender: seller_address.clone(),
             funds: vec![],
         };
         let env = mock_env();

--- a/src/tests/execute/execute_remove_as_seller.rs
+++ b/src/tests/execute/execute_remove_as_seller.rs
@@ -6,8 +6,8 @@ mod execute_remove_as_seller_tests {
     use crate::storage::state_store::{
         save_buyer_state, save_contract_config, save_seller_state, Buyer, Config, Seller,
     };
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
@@ -85,7 +85,7 @@ mod execute_remove_as_seller_tests {
         let buyer_address = deps.api.addr_make("contract_buyer");
         let token_denom = "test.forward.market.token";
         let info = MessageInfo {
-            sender:seller_address.clone(),
+            sender: seller_address.clone(),
             funds: vec![],
         };
         let env = mock_env();

--- a/src/tests/execute/execute_remove_as_seller.rs
+++ b/src/tests/execute/execute_remove_as_seller.rs
@@ -7,28 +7,32 @@ mod execute_remove_as_seller_tests {
         save_buyer_state, save_contract_config, save_seller_state, Buyer, Config, Seller,
     };
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute, Uint128};
+    use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
     fn execute_remove_as_seller() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "seller-0";
-        let buyer_address = "contract_buyer";
+        let seller_address = deps.api.addr_make("seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
+        let dealer_address = deps.api.addr_make("dealer-address");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(seller_address, &[]);
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(100000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
             },
         )
@@ -37,7 +41,7 @@ mod execute_remove_as_seller_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -53,7 +57,7 @@ mod execute_remove_as_seller_tests {
                     min_face_value_cents: Uint128::new(100000),
                     max_face_value_cents: Uint128::new(650000000),
                     tick_size: Uint128::new(1000),
-                    dealers: vec![Addr::unchecked("dealer-address")],
+                    dealers: vec![dealer_address.clone()],
                     is_disabled: false,
                 };
                 assert_eq!(response.attributes.len(), 1);
@@ -77,10 +81,13 @@ mod execute_remove_as_seller_tests {
     #[test]
     fn execute_remove_as_seller_not_private() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(seller_address, &[]);
+        let info = MessageInfo {
+            sender:seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
@@ -92,7 +99,7 @@ mod execute_remove_as_seller_tests {
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(100000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -101,7 +108,7 @@ mod execute_remove_as_seller_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -126,22 +133,25 @@ mod execute_remove_as_seller_tests {
     #[test]
     fn execute_remove_as_seller_not_in_list() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(seller_address, &[]);
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked("allowed-seller-1")],
+                allowed_sellers: vec![deps.api.addr_make("allowed-seller-1")],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(100000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -150,7 +160,7 @@ mod execute_remove_as_seller_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -178,22 +188,25 @@ mod execute_remove_as_seller_tests {
     #[test]
     fn execute_remove_as_seller_already_accepted() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract-buyer");
         let token_denom = "test.forward.market.token";
-        let info = mock_info(seller_address, &[]);
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: token_denom.into(),
                 max_face_value_cents: Uint128::new(650000000),
                 min_face_value_cents: Uint128::new(500000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -202,7 +215,7 @@ mod execute_remove_as_seller_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -211,7 +224,7 @@ mod execute_remove_as_seller_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(1000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),

--- a/src/tests/execute/execute_update_allowed_sellers.rs
+++ b/src/tests/execute/execute_update_allowed_sellers.rs
@@ -6,7 +6,7 @@ mod execute_update_allowed_sellers {
     use crate::query::contract_state::query_contract_state;
     use crate::storage::state_store::{save_buyer_state, save_contract_config, Buyer, Config};
     use crate::version_info::{set_version_info, VersionInfoV1};
-    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 

--- a/src/tests/execute/execute_update_face_value.rs
+++ b/src/tests/execute/execute_update_face_value.rs
@@ -6,8 +6,8 @@ mod execute_update_face_value {
     use crate::query::contract_state::query_contract_state;
     use crate::storage::state_store::{save_buyer_state, save_contract_config, Buyer, Config};
     use crate::version_info::{set_version_info, VersionInfoV1};
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]

--- a/src/tests/execute/execute_update_face_value.rs
+++ b/src/tests/execute/execute_update_face_value.rs
@@ -7,25 +7,31 @@ mod execute_update_face_value {
     use crate::storage::state_store::{save_buyer_state, save_contract_config, Buyer, Config};
     use crate::version_info::{set_version_info, VersionInfoV1};
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute, Uint128};
+    use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
     fn update_face_value_cents() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract_buyer", &[]);
+        let buyer_address = deps.api.addr_make("contract-buyer");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let info = MessageInfo {
+            sender: buyer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![Addr::unchecked("allowed-seller-0")],
+                allowed_sellers: vec![seller_address.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: "test.forward.market.token".into(),
                 max_face_value_cents: Uint128::new(9000000000),
                 min_face_value_cents: Uint128::new(500000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
             },
         )
@@ -43,7 +49,7 @@ mod execute_update_face_value {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked("contract_buyer"),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -59,13 +65,13 @@ mod execute_update_face_value {
             Ok(response) => {
                 let expected_config_attributes = Config {
                     is_private: true,
-                    allowed_sellers: vec![Addr::unchecked("allowed-seller-0")],
+                    allowed_sellers: vec![seller_address.clone()],
                     agreement_terms_hash: "mock-terms-hash".to_string(),
                     token_denom: "test.forward.market.token".to_string(),
                     min_face_value_cents: Uint128::new(7500000000),
                     max_face_value_cents: Uint128::new(8500000000),
                     tick_size: Uint128::new(1000),
-                    dealers: vec![Addr::unchecked("dealer-address")],
+                    dealers: vec![dealer_address.clone()],
                     is_disabled: false,
                 };
                 assert_eq!(response.attributes.len(), 1);
@@ -90,22 +96,25 @@ mod execute_update_face_value {
     #[test]
     fn update_face_value_with_unauthorized_buyer() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract_buyer_1", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make("contract-buyer-1"),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
                 allowed_sellers: vec![
-                    Addr::unchecked("allowed-seller-0"),
-                    Addr::unchecked("allowed-seller-1"),
+                    deps.api.addr_make("allowed-seller-0"),
+                    deps.api.addr_make("allowed-seller-1"),
                 ],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: "test.forward.market.token".into(),
                 max_face_value_cents: Uint128::new(500000000),
                 min_face_value_cents: Uint128::new(100000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -114,7 +123,7 @@ mod execute_update_face_value {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked("contract_buyer_0"),
+                buyer_address: deps.api.addr_make("contract_buyer_0"),
                 has_accepted_pools: false,
             },
         )

--- a/src/tests/execute/execute_update_terms_hash.rs
+++ b/src/tests/execute/execute_update_terms_hash.rs
@@ -7,28 +7,35 @@ mod execute_update_agreement_terms_hash {
     use crate::storage::state_store::{save_buyer_state, save_contract_config, Buyer, Config};
     use crate::version_info::{set_version_info, VersionInfoV1};
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute, Uint128};
+    use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
     fn update_terms_hash() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract_buyer", &[]);
+        let buyer_address = deps.api.addr_make("contract-buyer");
+        let seller_address_0 = deps.api.addr_make("allowed-seller-0");
+        let seller_address_1 = deps.api.addr_make("allowed-seller-1");
+        let dealer_address = deps.api.addr_make("dealer");
+        let info = MessageInfo {
+            sender: buyer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
                 allowed_sellers: vec![
-                    Addr::unchecked("allowed-seller-0"),
-                    Addr::unchecked("allowed-seller-1"),
+                    seller_address_0.clone(),
+                    seller_address_1.clone(),
                 ],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: "test.forward.market.token".into(),
                 max_face_value_cents: Uint128::new(500000000),
                 min_face_value_cents: Uint128::new(100000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
             },
         )
@@ -46,7 +53,7 @@ mod execute_update_agreement_terms_hash {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked("contract_buyer"),
+                buyer_address: buyer_address.clone(),
                 has_accepted_pools: false,
             },
         )
@@ -60,15 +67,15 @@ mod execute_update_agreement_terms_hash {
                 let expected_config_attributes = Config {
                     is_private: true,
                     allowed_sellers: vec![
-                        Addr::unchecked("allowed-seller-0"),
-                        Addr::unchecked("allowed-seller-1"),
+                        seller_address_0.clone(),
+                        seller_address_1.clone(),
                     ],
                     agreement_terms_hash: "updated-mock-terms-hash".to_string(),
                     token_denom: "test.forward.market.token".to_string(),
                     min_face_value_cents: Uint128::new(100000000),
                     max_face_value_cents: Uint128::new(500000000),
                     tick_size: Uint128::new(1000),
-                    dealers: vec![Addr::unchecked("dealer-address")],
+                    dealers: vec![dealer_address.clone()],
                     is_disabled: false,
                 };
                 assert_eq!(response.attributes.len(), 1);
@@ -93,22 +100,25 @@ mod execute_update_agreement_terms_hash {
     #[test]
     fn update_terms_hash_with_unauthorized_buyer() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract_buyer_0", &[]);
+        let info = MessageInfo {
+            sender: deps.api.addr_make("contract-buyer-0"),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 is_private: true,
                 allowed_sellers: vec![
-                    Addr::unchecked("allowed-seller-0"),
-                    Addr::unchecked("allowed-seller-1"),
+                    deps.api.addr_make("allowed-seller-0"),
+                    deps.api.addr_make("allowed-seller-1"),
                 ],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: "test.forward.market.token".into(),
                 max_face_value_cents: Uint128::new(500000000),
                 min_face_value_cents: Uint128::new(100000000),
                 tick_size: Uint128::new(1000),
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
             },
         )
@@ -117,7 +127,7 @@ mod execute_update_agreement_terms_hash {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked("contract_buyer_1"),
+                buyer_address: deps.api.addr_make("contract_buyer_1"),
                 has_accepted_pools: false,
             },
         )

--- a/src/tests/execute/execute_update_terms_hash.rs
+++ b/src/tests/execute/execute_update_terms_hash.rs
@@ -6,8 +6,8 @@ mod execute_update_agreement_terms_hash {
     use crate::query::contract_state::query_contract_state;
     use crate::storage::state_store::{save_buyer_state, save_contract_config, Buyer, Config};
     use crate::version_info::{set_version_info, VersionInfoV1};
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute, MessageInfo, Uint128};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{Attribute, MessageInfo, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
@@ -26,10 +26,7 @@ mod execute_update_agreement_terms_hash {
             &mut deps.storage,
             &Config {
                 is_private: true,
-                allowed_sellers: vec![
-                    seller_address_0.clone(),
-                    seller_address_1.clone(),
-                ],
+                allowed_sellers: vec![seller_address_0.clone(), seller_address_1.clone()],
                 agreement_terms_hash: "mock-terms-hash".to_string(),
                 token_denom: "test.forward.market.token".into(),
                 max_face_value_cents: Uint128::new(500000000),
@@ -66,10 +63,7 @@ mod execute_update_agreement_terms_hash {
             Ok(response) => {
                 let expected_config_attributes = Config {
                     is_private: true,
-                    allowed_sellers: vec![
-                        seller_address_0.clone(),
-                        seller_address_1.clone(),
-                    ],
+                    allowed_sellers: vec![seller_address_0.clone(), seller_address_1.clone()],
                     agreement_terms_hash: "updated-mock-terms-hash".to_string(),
                     token_denom: "test.forward.market.token".to_string(),
                     min_face_value_cents: Uint128::new(100000000),

--- a/src/tests/instantiate/instantiate_tests.rs
+++ b/src/tests/instantiate/instantiate_tests.rs
@@ -6,7 +6,7 @@ mod instantiate_tests {
     use crate::query::contract_state::query_contract_state;
     use crate::storage::state_store::{retrieve_buyer_state, Config};
     use crate::version_info::{get_version_info, VersionInfoV1, CRATE_NAME, PACKAGE_VERSION};
-    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{Addr, Attribute, MessageInfo, Storage, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
@@ -24,7 +24,10 @@ mod instantiate_tests {
         let env = mock_env();
         let instantiate_msg = InstantiateContractMsg {
             is_private: true,
-            allowed_sellers: vec![seller_address_0.clone().to_string(), seller_address_1.clone().to_string()],
+            allowed_sellers: vec![
+                seller_address_0.clone().to_string(),
+                seller_address_1.clone().to_string(),
+            ],
             agreement_terms_hash: "mock-terms-hash".to_string(),
             token_denom: "test.forward.market.token".to_string(),
             min_face_value_cents: Uint128::new(1000000),
@@ -37,10 +40,7 @@ mod instantiate_tests {
             Ok(response) => {
                 let expected_config_attributes = Config {
                     is_private: true,
-                    allowed_sellers: vec![
-                        seller_address_0.clone(),
-                        seller_address_1.clone(),
-                    ],
+                    allowed_sellers: vec![seller_address_0.clone(), seller_address_1.clone()],
                     agreement_terms_hash: "mock-terms-hash".to_string(),
                     token_denom: "test.forward.market.token".to_string(),
                     min_face_value_cents: Uint128::new(1000000),
@@ -72,10 +72,7 @@ mod instantiate_tests {
                     expected_version_info
                 );
 
-                assert_eq!(
-                    get_buyer_address(&deps.storage),
-                    buyer_address.clone()
-                )
+                assert_eq!(get_buyer_address(&deps.storage), buyer_address.clone())
             }
             Err(error) => {
                 panic!("failed to initialize: {:?}", error)
@@ -94,7 +91,10 @@ mod instantiate_tests {
         let env = mock_env();
         let instantiate_msg = InstantiateContractMsg {
             is_private: false,
-            allowed_sellers: vec![deps.api.addr_make("allowed-seller-0").to_string(), deps.api.addr_make("allowed-seller-1").to_string()],
+            allowed_sellers: vec![
+                deps.api.addr_make("allowed-seller-0").to_string(),
+                deps.api.addr_make("allowed-seller-1").to_string(),
+            ],
             agreement_terms_hash: "mock-terms-hash".to_string(),
             token_denom: "test.forward.market.token".to_string(),
             min_face_value_cents: Uint128::new(1000000),
@@ -128,7 +128,10 @@ mod instantiate_tests {
         let env = mock_env();
         let instantiate_msg = InstantiateContractMsg {
             is_private: true,
-            allowed_sellers: vec![deps.api.addr_make("allowed-seller-0").to_string(), deps.api.addr_make("allowed-seller-1").to_string()],
+            allowed_sellers: vec![
+                deps.api.addr_make("allowed-seller-0").to_string(),
+                deps.api.addr_make("allowed-seller-1").to_string(),
+            ],
             agreement_terms_hash: "mock-terms-hash".to_string(),
             token_denom: "test.forward.market.token".to_string(),
             min_face_value_cents: Uint128::new(0),

--- a/src/util/helpers.rs
+++ b/src/util/helpers.rs
@@ -42,10 +42,7 @@ pub fn create_and_transfer_marker(
         // Give the dealers access to withdraw and transfer only
         access_grants.push(AccessGrant {
             address: access_address.to_string(),
-            permissions: vec![
-                Access::Withdraw as i32,
-                Access::Deposit as i32,
-            ],
+            permissions: vec![Access::Withdraw as i32, Access::Deposit as i32],
         })
     }
 

--- a/src/util/helpers.rs
+++ b/src/util/helpers.rs
@@ -74,6 +74,9 @@ pub fn create_and_transfer_marker(
         allow_governance_control: true,
         allow_forced_transfer: false,
         required_attributes: vec![],
+        usd_cents: 0,
+        volume: 0,
+        usd_mills: 0,
     }));
 
     messages.push(CosmosMsg::from(MsgFinalizeRequest {
@@ -107,6 +110,7 @@ pub fn get_owned_scopes(
     let metadata_querier = MetadataQuerier::new(querier);
     metadata_querier.value_ownership(
         marker_address,
+        true,
         Some(PageRequest {
             key: vec![],
             offset,


### PR DESCRIPTION
Provenance version 1.19 introduces some breaking changes for smart contracts. This PR updates the provwasm-std library to v2.3.0 and updates the unit tests to use valid bech32 addresses