### PR TITLE
Upgrade FM v1.1.2 contract to be compatible with Provenance v1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,149 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.80"
+name = "ahash"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+ "rayon",
+]
 
 [[package]]
 name = "arrayvec"
@@ -27,15 +166,18 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atomic"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -50,16 +192,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitvec"
@@ -75,15 +223,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -93,15 +232,15 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -109,15 +248,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.71",
  "syn_derive",
 ]
 
@@ -144,16 +283,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "bytemuck"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cfg-if"
@@ -163,15 +302,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "num-traits",
 ]
@@ -183,33 +322,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "cosmwasm-crypto"
-version = "1.5.3"
+name = "cosmwasm-core"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
+checksum = "8d075f6bb1483a6ce83b5cbc73a3a1207e0316ac1e34ed1f2a4d9fc3a0f07bf6"
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ced5a6dd2801a383d3e14e5ae5caa7fdfeff1bd9f22b30e810e0aded8a5869"
 dependencies = [
- "digest 0.10.7",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "cosmwasm-core",
+ "digest",
  "ecdsa",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.4",
+ "num-traits",
+ "p256",
+ "rand_core",
+ "rayon",
+ "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
+checksum = "35bd1873f84d9b17edf8a90ffe10a89a649b82feacc00e36788b81d2c3cbf03c"
 dependencies = [
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e3a2136e2a60e8b6582f5dffca5d1a683ed77bf38537d330bc1dfccd69010"
+checksum = "27984b137eb2ac561f97f6bdb02004a98eb6f2ba263062c140b8e231ee1826b7"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -220,33 +376,34 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d803bea6bd9ed61bd1ee0b4a2eb09ee20dbb539cc6e0b8795614d20952ebb1"
+checksum = "f4ef0d201f611bdb6c9124207032423eb956f1fc8ab3e3ee7253a9c08a5f5809"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
+checksum = "2522fb5c9a0409712bb1d036128bccf3564e6b2ac82f942ae4cf3c8df3e26fa8"
 dependencies = [
- "base64",
- "bech32",
+ "base64 0.22.1",
+ "bech32 0.11.0",
  "bnum",
+ "cosmwasm-core",
  "cosmwasm-crypto",
  "cosmwasm-derive",
- "derivative",
- "forward_ref",
+ "derive_more",
  "hex",
+ "rand_core",
  "schemars",
  "serde",
  "serde-json-wasm",
- "sha2 0.10.8",
+ "sha2",
  "static_assertions",
  "thiserror",
 ]
@@ -261,13 +418,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -284,22 +466,36 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "cw-storage-plus"
-version = "1.2.0"
+name = "curve25519-dalek-derive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13360e9007f51998d42b1bc6b7fa0141f74feae61ed5fd1e5b0a89eec7b5de1"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -308,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.1.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
+checksum = "b04852cd38f044c0751259d5f78255d07590d136b8a86d4e09efdd7666bd6d27"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -323,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -343,12 +539,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.9.0"
+name = "derive_more"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
 dependencies = [
- "generic-array",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -357,7 +565,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -376,33 +584,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek",
- "hashbrown 0.12.3",
+ "ed25519",
+ "hashbrown 0.14.5",
  "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.9.9",
+ "rand_core",
+ "sha2",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -412,12 +628,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -435,37 +650,37 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "forward_market_contract"
-version = "1.0.0"
+version = "0.1.2"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
  "hex",
  "log",
- "prost",
+ "prost 0.11.9",
  "provwasm-mocks",
  "provwasm-std",
  "rust_decimal",
  "schemars",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
  "uuid",
 ]
-
-[[package]]
-name = "forward_ref"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "funty"
@@ -486,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -502,7 +717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -512,14 +727,27 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.11",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -539,17 +767,17 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -571,48 +799,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
+name = "itertools"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2 0.10.8",
- "signature",
+ "sha2",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -624,26 +878,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
+name = "p256"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -679,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -693,45 +958,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
 ]
 
 [[package]]
 name = "provwasm-common"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938fe0a8914598b5aa201221ce2d9c5388412e348ea312bcba36b5077376b96d"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "cosmwasm-std",
 ]
 
 [[package]]
 name = "provwasm-mocks"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1143b9d41f537559d30a3cbbcbaa3a196f829fc298daaa4bbacd5ca90309950"
+version = "2.3.0"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "cosmwasm-std",
  "provwasm-common",
@@ -742,27 +1014,27 @@ dependencies = [
 
 [[package]]
 name = "provwasm-proc-macro"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d3d936fc7e0fac992a454ec731aeded01166a894719d9161f261fc713ce251"
+version = "0.1.2"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
+ "prost-types",
+ "provwasm-common",
  "quote",
- "syn 2.0.52",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "provwasm-std"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1be9fcaa463174e3bec59a179ed5b3590aa038f0e9c68d5132bc19df212383"
+version = "2.3.0"
+source = "git+https://github.com/provenance-io/provwasm?tag=v2.3.0-rc1#40ffc8fc46dbe676b70a4fbd7b6a8deeb9b572d4"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "cosmwasm-schema",
  "cosmwasm-std",
- "prost",
+ "prost 0.12.6",
  "prost-types",
  "provwasm-common",
  "provwasm-proc-macro",
@@ -794,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -815,7 +1087,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -825,14 +1097,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -841,6 +1107,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -893,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -908,22 +1194,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
+name = "rustc_version"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schemars"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -933,14 +1228,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -958,22 +1253,21 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -989,57 +1283,44 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
+checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -1050,7 +1331,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1059,8 +1340,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1070,16 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,22 +1358,22 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1117,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1135,7 +1406,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1146,29 +1417,29 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1181,9 +1452,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -1209,10 +1480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "uuid"
-version = "1.7.0"
+name = "unicode-xid"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "atomic",
 ]
@@ -1248,7 +1525,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.7.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_market_contract"
-version = "1.0.0"
+version = "0.1.2"
 authors = ["Jordon Tolotti <jtolotti@figure.com>"]
 edition = "2021"
 
@@ -19,8 +19,6 @@ incremental = false
 overflow-checks = true
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
@@ -32,14 +30,14 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-schema = "1.2.8"
-cosmwasm-std = { version = "1.2.5", features = ["stargate"]}
-cw-storage-plus = "1.1.0"
-cw2 = "1.0.0"
+cosmwasm-schema = "2.1.0"
+cosmwasm-std = { version = "2.1.0"}
+cw-storage-plus = "2.0.0"
+cw2 = "2.0.0"
 schemars = "0.8.15"
 serde = { version = "1.0.189", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.49" }
-provwasm-std = { version = "=2.1.0"}
+provwasm-std = { git = "https://github.com/provenance-io/provwasm", tag = "v2.3.0-rc1" }
 sha2 = "0.10.8"
 hex = "0.4.3"
 bech32 = "0.9.1"
@@ -47,6 +45,7 @@ rust_decimal = "1.29.0"
 uuid = { version = "1.7.0", features = ["v1"] }
 log = "0.4.21"
 
+
 [dev-dependencies]
-provwasm-mocks = { version = "=2.1.0" }
+provwasm-mocks = { git = "https://github.com/provenance-io/provwasm", tag = "v2.3.0-rc1" }
 prost = { version = "=0.11.9", default-features = false }

--- a/src/execute/accept_bid.rs
+++ b/src/execute/accept_bid.rs
@@ -30,7 +30,7 @@ pub fn execute_accept_bid(
     let bid: Option<Bid> = bid_list
         .bids
         .into_iter()
-        .find(|existing_bid| -> bool { existing_bid.buyer_address == bidder_address_str });
+        .find(|existing_bid| -> bool { existing_bid.buyer_address.to_string() == bidder_address_str });
 
     match bid {
         None => {

--- a/src/tests/execute/execute_dealer_confirm.rs
+++ b/src/tests/execute/execute_dealer_confirm.rs
@@ -55,7 +55,7 @@ mod execute_dealer_confirm_tests {
             &mut deps.storage,
             &BidList {
                 bids: vec![Bid {
-                    buyer_address: Addr::unchecked(buyer_address),
+                    buyer_address: buyer_address.clone(),
                     agreement_terms_hash: "".to_string(),
                 }],
             },
@@ -368,7 +368,7 @@ mod execute_dealer_confirm_tests {
                 use_private_buyers: false,
                 allowed_sellers: vec![],
                 allowed_buyers: vec![],
-                dealers: vec![dealer_address],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
                 max_bid_count: 50,
                 contract_admin: deps.api.addr_make("contract-admin"),

--- a/src/tests/execute/execute_dealer_confirm.rs
+++ b/src/tests/execute/execute_dealer_confirm.rs
@@ -2,11 +2,10 @@
 mod execute_dealer_confirm_tests {
     use crate::contract::execute;
     use crate::error::ContractError;
-    use crate::storage::state_store::{retrieve_optional_settlement_data_state, save_bid_list_state, save_contract_config, save_seller_state, save_settlement_data_state, Bid, Config, Seller, SettlementData, BidList, save_buyer_state, Buyer, save_token_data_state, TokenData};
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{to_json_binary, Binary, ContractResult, SystemResult};
+    use crate::storage::state_store::{retrieve_optional_settlement_data_state, save_buyer_state, save_contract_config, save_seller_state, save_settlement_data_state, Buyer, Config, Seller, SettlementData, Bid, BidList, save_bid_list_state, save_token_data_state, TokenData};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{to_json_binary, Binary, ContractResult, MessageInfo, SystemResult};
     use cosmwasm_std::{Addr, CosmosMsg, Uint128};
-    use prost::Message;
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::shim::Any;
     use provwasm_std::types::cosmos::auth::v1beta1::BaseAccount;
@@ -26,20 +25,24 @@ mod execute_dealer_confirm_tests {
     #[test]
     fn execute_dealer_confirm() {
         let mut deps = mock_provenance_dependencies();
-        let dealer_address = "dealer-address";
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let pool_denom = "test.token.asset.pool.0";
-        let info = mock_info(dealer_address, &[]);
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: dealer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 use_private_sellers: true,
                 use_private_buyers: false,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked(dealer_address)],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
                 max_bid_count: 3,
                 contract_admin: Addr::unchecked("contract_admin"),
@@ -62,7 +65,7 @@ mod execute_dealer_confirm_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(550000000),
                 pool_denoms,
                 offer_hash: "mock-offer-hash".to_string(),
@@ -73,7 +76,7 @@ mod execute_dealer_confirm_tests {
         save_buyer_state(
             &mut deps.storage,
             &Buyer {
-                buyer_address: Addr::unchecked(buyer_address),
+                buyer_address: buyer_address.clone(),
                 buyer_has_accepted_pools: true,
                 agreement_terms_hash: "".to_string(),
             },
@@ -87,10 +90,10 @@ mod execute_dealer_confirm_tests {
 
         let cb = Box::new(|bin: &Binary| -> SystemResult<ContractResult<Binary>> {
             let message = QueryMarkerRequest::try_from(bin.clone()).unwrap();
-
+            let inner_deps = mock_provenance_dependencies();
             let expected_marker = MarkerAccount {
                 base_account: Some(BaseAccount {
-                    address: "base_addr".to_string(),
+                    address: inner_deps.api.addr_make("base_addr").to_string(),
                     pub_key: None,
                     account_number: 1,
                     sequence: 0,
@@ -113,7 +116,7 @@ mod execute_dealer_confirm_tests {
             let response = QueryMarkerResponse {
                 marker: Some(Any {
                     type_url: "/provenance.marker.v1.MarkerAccount".to_string(),
-                    value: expected_marker.encode_to_vec(),
+                    value: expected_marker.to_proto_bytes(),
                 }),
             };
 
@@ -122,12 +125,13 @@ mod execute_dealer_confirm_tests {
         });
 
         let cb_holding = Box::new(|bin: &Binary| -> SystemResult<ContractResult<Binary>> {
+            let inner_deps = mock_provenance_dependencies();
             let message = QueryHoldingRequest::try_from(bin.clone()).unwrap();
 
             let response = if message.id == "test.token.asset.pool.0" {
                 QueryHoldingResponse {
                     balances: vec![Balance {
-                        address: seller_address.to_string(),
+                        address: inner_deps.api.addr_make("seller_address").to_string(),
                         coins: vec![Coin {
                             denom: "test.token.asset.pool.0".to_string(),
                             amount: "1".to_string(),
@@ -167,13 +171,13 @@ mod execute_dealer_confirm_tests {
                         }),
                         administrator: env.contract.address.to_string(),
                         from_address: env.contract.address.to_string(),
-                        to_address: "base_addr".to_string(),
+                        to_address: deps.api.addr_make("base_addr").to_string(),
                     })
                 );
 
                 let expected_settlement_data = SettlementData {
                     block_height: 12345,
-                    settling_dealer: Addr::unchecked(dealer_address),
+                    settling_dealer: dealer_address.clone(),
                 };
                 assert_eq!(
                     expected_settlement_data,
@@ -194,23 +198,27 @@ mod execute_dealer_confirm_tests {
     #[test]
     fn execute_seller_confirm_invalid_seller() {
         let mut deps = mock_provenance_dependencies();
-        let dealer_address = "dealer-address";
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract-buyer");
         let pool_denom = "test.token.asset.pool.0";
-        let info = mock_info(dealer_address, &[]);
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: dealer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 use_private_sellers: true,
                 use_private_buyers: false,
-                allowed_sellers: vec![Addr::unchecked("different_seller")],
+                allowed_sellers: vec![deps.api.addr_make("different-seller")],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked(dealer_address)],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
                 max_bid_count: 2,
-                contract_admin: Addr::unchecked("contract-admin"),
+                contract_admin: deps.api.addr_make("contract-admin"),
             },
         )
         .unwrap();
@@ -220,7 +228,7 @@ mod execute_dealer_confirm_tests {
             &mut deps.storage,
             &BidList {
                 bids: vec![Bid {
-                    buyer_address: Addr::unchecked(buyer_address),
+                    buyer_address: buyer_address.clone(),
                     agreement_terms_hash: "".to_string(),
                 }],
             },
@@ -230,7 +238,7 @@ mod execute_dealer_confirm_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(550000000),
                 pool_denoms,
                 offer_hash: "mock-offer-hash".to_string(),
@@ -278,13 +286,17 @@ mod execute_dealer_confirm_tests {
     }
 
     #[test]
-    fn execute_seller_confirm_unauthorized_seller() {
+    fn execute_seller_confirm_unauthorized_dealer() {
         let mut deps = mock_provenance_dependencies();
-        let dealer_address = "dealer-address";
-        let seller_address = "allowed-seller-0";
-        let buyer_address = "contract_buyer";
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
         let pool_denom = "test.token.asset.pool.0";
-        let info = mock_info("not-the-dealer", &[]);
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: deps.api.addr_make("not-the-dealer"),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
@@ -293,7 +305,7 @@ mod execute_dealer_confirm_tests {
                 use_private_buyers: false,
                 allowed_sellers: vec![Addr::unchecked("different_seller")],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked(dealer_address)],
+                dealers: vec![dealer_address.clone()],
                 is_disabled: false,
                 max_bid_count: 5,
                 contract_admin: Addr::unchecked("contract-admin"),
@@ -306,7 +318,7 @@ mod execute_dealer_confirm_tests {
             &mut deps.storage,
             &BidList {
                 bids: vec![Bid {
-                    buyer_address: Addr::unchecked(buyer_address),
+                    buyer_address: buyer_address.clone(),
                     agreement_terms_hash: "".to_string(),
                 }],
             },
@@ -316,19 +328,14 @@ mod execute_dealer_confirm_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(550000000),
                 pool_denoms,
                 offer_hash: "mock-offer-hash".to_string(),
             },
         )
         .unwrap();
-        match execute(
-            deps.as_mut(),
-            env.clone(),
-            info,
-            crate::msg::ExecuteMsg::DealerConfirm {},
-        ) {
+        match execute(deps.as_mut(), env.clone(), info, DealerConfirm {}) {
             Ok(_) => {
                 panic!(
                     "failed to return an error when an unauthorized seller attempted to confirm the contract"
@@ -348,7 +355,11 @@ mod execute_dealer_confirm_tests {
     #[test]
     fn disallow_all_executions_after_settlement() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("", &[]);
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let info = MessageInfo {
+            sender: deps.api.addr_make(""),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
@@ -357,10 +368,10 @@ mod execute_dealer_confirm_tests {
                 use_private_buyers: false,
                 allowed_sellers: vec![],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![dealer_address],
                 is_disabled: false,
                 max_bid_count: 50,
-                contract_admin: Addr::unchecked("contract-admin"),
+                contract_admin: deps.api.addr_make("contract-admin"),
             },
         )
         .unwrap();
@@ -368,7 +379,7 @@ mod execute_dealer_confirm_tests {
             &mut deps.storage,
             &BidList {
                 bids: vec![Bid {
-                    buyer_address: Addr::unchecked("buyer-address"),
+                    buyer_address: deps.api.addr_make("buyer-address"),
                     agreement_terms_hash: "".to_string(),
                 }],
             },
@@ -378,7 +389,7 @@ mod execute_dealer_confirm_tests {
             &mut deps.storage,
             &SettlementData {
                 block_height: 1,
-                settling_dealer: Addr::unchecked("dealer-address"),
+                settling_dealer: dealer_address.clone(),
             },
         )
         .unwrap();

--- a/src/tests/execute/execute_disable_contract.rs
+++ b/src/tests/execute/execute_disable_contract.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod execute_disable_contract_tests {
-    use std::fmt::Binary;
     use crate::contract::execute;
     use crate::error::ContractError;
     use crate::msg::ExecuteMsg::{
@@ -9,7 +8,7 @@ mod execute_disable_contract_tests {
         UpdateAllowedSellers,
     };
     use cosmwasm_std::testing::mock_env;
-    use cosmwasm_std::{ContractResult, MessageInfo, SystemResult, to_json_binary, Uint128};
+    use cosmwasm_std::{Binary, ContractResult, MessageInfo, SystemResult, to_json_binary, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::types::cosmos::base::v1beta1::Coin;
     use provwasm_std::types::provenance::marker::v1::{Balance, QueryHoldingRequest, QueryHoldingResponse};
@@ -151,7 +150,7 @@ mod execute_disable_contract_tests {
         )
             .unwrap();
 
-        let cb = Box::new(|bin: &dyn Binary| -> SystemResult<ContractResult<dyn Binary>> {
+        let cb = Box::new(|bin: &Binary| -> SystemResult<ContractResult<Binary>> {
             let message = QueryHoldingRequest::try_from(bin.clone()).unwrap();
 
             let response = if message.id == "test.denom.pool.0".to_string() {

--- a/src/tests/execute/execute_finalize_pools.rs
+++ b/src/tests/execute/execute_finalize_pools.rs
@@ -4,9 +4,9 @@ mod execute_finalize_pools_tests {
     use crate::error::ContractError;
     use crate::msg::ExecuteMsg::FinalizePools;
     use crate::storage::state_store::{save_contract_config, save_seller_state, Config, Seller};
-    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{
-        to_json_binary, Addr, Attribute, Binary, ContractResult, SystemResult, Uint128,
+        to_json_binary, Attribute, Binary, ContractResult, MessageInfo, SystemResult, Uint128,
     };
     use provwasm_mocks::mock_provenance_dependencies;
     use provwasm_std::types::cosmos::base::v1beta1::Coin;
@@ -17,21 +17,25 @@ mod execute_finalize_pools_tests {
     #[test]
     fn execute_finalize_pool() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
+        let seller_address = deps.api.addr_make("allowed-seller-0");
         let pool_denom = "test.token.asset.pool.0";
-        let info = mock_info(seller_address, &[]);
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 use_private_sellers: true,
                 use_private_buyers: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
                 max_bid_count: 1,
-                contract_admin: Addr::unchecked("contract-admin"),
+                contract_admin: deps.api.addr_make("contract-admin"),
             },
         )
         .unwrap();
@@ -40,7 +44,7 @@ mod execute_finalize_pools_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(650000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),
@@ -52,9 +56,10 @@ mod execute_finalize_pools_tests {
             let message = QueryHoldingRequest::try_from(bin.clone()).unwrap();
 
             let response = if message.id == "test.token.asset.pool.0" {
+                let inner_deps = mock_provenance_dependencies();
                 QueryHoldingResponse {
                     balances: vec![Balance {
-                        address: seller_address.to_string(),
+                        address: inner_deps.api.addr_make("allowed-seller-0").to_string(),
                         coins: vec![Coin {
                             denom: "test.token.asset.pool.0".to_string(),
                             amount: "2".to_string(),
@@ -81,7 +86,7 @@ mod execute_finalize_pools_tests {
         ) {
             Ok(response) => {
                 let expected_seller_state = Seller {
-                    seller_address: Addr::unchecked(seller_address),
+                    seller_address: seller_address.clone(),
                     accepted_value_cents: Uint128::new(650000000),
                     pool_denoms: vec![pool_denom.into()],
                     offer_hash: "mock-offer-hash".to_string(),
@@ -101,8 +106,12 @@ mod execute_finalize_pools_tests {
     #[test]
     fn execute_finalize_pool_invalid_list() {
         let mut deps = mock_provenance_dependencies();
-        let seller_address = "allowed-seller-0";
-        let info = mock_info(seller_address, &[]);
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
 
         save_contract_config(
@@ -110,12 +119,12 @@ mod execute_finalize_pools_tests {
             &Config {
                 use_private_sellers: true,
                 use_private_buyers: true,
-                allowed_sellers: vec![Addr::unchecked(seller_address)],
+                allowed_sellers: vec![seller_address.clone()],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
                 max_bid_count: 2,
-                contract_admin: Addr::unchecked("contract-admin"),
+                contract_admin: deps.api.addr_make("contract-admin"),
             },
         )
         .unwrap();
@@ -123,7 +132,7 @@ mod execute_finalize_pools_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(seller_address),
+                seller_address: seller_address.clone(),
                 accepted_value_cents: Uint128::new(650000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),
@@ -157,21 +166,25 @@ mod execute_finalize_pools_tests {
     #[test]
     fn execute_finalize_pool_not_seller() {
         let mut deps = mock_provenance_dependencies();
-        let unauthorized_seller_address = "unauthorized-seller";
-        let allowed_seller_address = "allowed-seller";
-        let info = mock_info(unauthorized_seller_address, &[]);
+        let unauthorized_seller_address = deps.api.addr_make("unauthorized-seller");
+        let allowed_seller_address = deps.api.addr_make("allowed-seller");
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: unauthorized_seller_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         save_contract_config(
             &mut deps.storage,
             &Config {
                 use_private_sellers: true,
                 use_private_buyers: true,
-                allowed_sellers: vec![Addr::unchecked(allowed_seller_address)],
+                allowed_sellers: vec![allowed_seller_address.clone()],
                 allowed_buyers: vec![],
-                dealers: vec![Addr::unchecked("dealer-address")],
+                dealers: vec![deps.api.addr_make("dealer-address")],
                 is_disabled: false,
                 max_bid_count: 2,
-                contract_admin: Addr::unchecked("contract-admin"),
+                contract_admin: deps.api.addr_make("contract-admin"),
             },
         )
         .unwrap();
@@ -179,7 +192,7 @@ mod execute_finalize_pools_tests {
         save_seller_state(
             &mut deps.storage,
             &Seller {
-                seller_address: Addr::unchecked(allowed_seller_address),
+                seller_address: allowed_seller_address.clone(),
                 accepted_value_cents: Uint128::new(650000000),
                 pool_denoms: vec![],
                 offer_hash: "mock-offer-hash".to_string(),

--- a/src/tests/execute/execute_remove_as_seller.rs
+++ b/src/tests/execute/execute_remove_as_seller.rs
@@ -1,0 +1,253 @@
+#[cfg(test)]
+mod execute_remove_as_seller_tests {
+    use crate::contract::execute;
+    use crate::error::ContractError;
+    use crate::msg::ExecuteMsg::RemoveAsSeller;
+    use crate::storage::state_store::{
+        save_buyer_state, save_contract_config, save_seller_state, Buyer, Config, Seller,
+    };
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{Attribute, MessageInfo, Uint128};
+    use provwasm_mocks::mock_provenance_dependencies;
+
+    #[test]
+    fn execute_remove_as_seller() {
+        let mut deps = mock_provenance_dependencies();
+        let seller_address = deps.api.addr_make("seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
+        let env = mock_env();
+        save_contract_config(
+            &mut deps.storage,
+            &Config {
+                is_private: true,
+                allowed_sellers: vec![seller_address.clone()],
+                agreement_terms_hash: "mock-terms-hash".to_string(),
+                token_denom: token_denom.into(),
+                max_face_value_cents: Uint128::new(650000000),
+                min_face_value_cents: Uint128::new(100000),
+                tick_size: Uint128::new(1000),
+                dealers: vec![dealer_address.clone()],
+                is_disabled: false,
+            },
+        )
+        .unwrap();
+
+        save_buyer_state(
+            &mut deps.storage,
+            &Buyer {
+                buyer_address: buyer_address.clone(),
+                has_accepted_pools: false,
+            },
+        )
+        .unwrap();
+
+        match execute(deps.as_mut(), env.clone(), info, RemoveAsSeller {}) {
+            Ok(response) => {
+                let expected_config_attributes = Config {
+                    is_private: true,
+                    allowed_sellers: vec![],
+                    agreement_terms_hash: "mock-terms-hash".to_string(),
+                    token_denom: token_denom.to_string(),
+                    min_face_value_cents: Uint128::new(100000),
+                    max_face_value_cents: Uint128::new(650000000),
+                    tick_size: Uint128::new(1000),
+                    dealers: vec![dealer_address.clone()],
+                    is_disabled: false,
+                };
+                assert_eq!(response.attributes.len(), 1);
+                assert_eq!(
+                    response.attributes[0],
+                    Attribute::new(
+                        "contract_config",
+                        format!("{:?}", expected_config_attributes)
+                    )
+                );
+            }
+            Err(error) => {
+                panic!(
+                    "failed to remove the seller from the allowed seller's list: {:?}",
+                    error
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn execute_remove_as_seller_not_private() {
+        let mut deps = mock_provenance_dependencies();
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
+        let env = mock_env();
+        save_contract_config(
+            &mut deps.storage,
+            &Config {
+                is_private: false,
+                allowed_sellers: vec![],
+                agreement_terms_hash: "mock-terms-hash".to_string(),
+                token_denom: token_denom.into(),
+                max_face_value_cents: Uint128::new(650000000),
+                min_face_value_cents: Uint128::new(100000),
+                tick_size: Uint128::new(1000),
+                dealers: vec![deps.api.addr_make("dealer-address")],
+                is_disabled: false,
+            },
+        )
+        .unwrap();
+
+        save_buyer_state(
+            &mut deps.storage,
+            &Buyer {
+                buyer_address: buyer_address.clone(),
+                has_accepted_pools: false,
+            },
+        )
+        .unwrap();
+
+        match execute(deps.as_mut(), env.clone(), info, RemoveAsSeller {}) {
+            Ok(_) => {
+                panic!("failed to detect error when removing a seller on a public contract")
+            }
+            Err(error) => match error {
+                ContractError::InvalidSellerRemovalRequest => {}
+                _ => {
+                    panic!(
+                        "Unexpected error encountered when attempting to remove a seller \
+                        from a public contract"
+                    )
+                }
+            },
+        }
+    }
+
+    #[test]
+    fn execute_remove_as_seller_not_in_list() {
+        let mut deps = mock_provenance_dependencies();
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract_buyer");
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
+        let env = mock_env();
+        save_contract_config(
+            &mut deps.storage,
+            &Config {
+                is_private: true,
+                allowed_sellers: vec![deps.api.addr_make("allowed-seller-1")],
+                agreement_terms_hash: "mock-terms-hash".to_string(),
+                token_denom: token_denom.into(),
+                max_face_value_cents: Uint128::new(650000000),
+                min_face_value_cents: Uint128::new(100000),
+                tick_size: Uint128::new(1000),
+                dealers: vec![deps.api.addr_make("dealer-address")],
+                is_disabled: false,
+            },
+        )
+        .unwrap();
+
+        save_buyer_state(
+            &mut deps.storage,
+            &Buyer {
+                buyer_address: buyer_address.clone(),
+                has_accepted_pools: false,
+            },
+        )
+        .unwrap();
+
+        match execute(deps.as_mut(), env.clone(), info, RemoveAsSeller {}) {
+            Ok(_) => {
+                panic!(
+                    "failed to detect error when removing a seller that is not in the list \
+                of allowed sellers"
+                )
+            }
+            Err(error) => match error {
+                ContractError::IllegalSellerRemovalRequest => {}
+                _ => {
+                    panic!(
+                        "Unexpected error encountered when attempting to remove a seller \
+                        that is not in the list of allowed sellers"
+                    )
+                }
+            },
+        }
+    }
+
+    #[test]
+    fn execute_remove_as_seller_already_accepted() {
+        let mut deps = mock_provenance_dependencies();
+        let seller_address = deps.api.addr_make("allowed-seller-0");
+        let buyer_address = deps.api.addr_make("contract-buyer");
+        let token_denom = "test.forward.market.token";
+        let info = MessageInfo {
+            sender: seller_address.clone(),
+            funds: vec![],
+        };
+        let env = mock_env();
+        save_contract_config(
+            &mut deps.storage,
+            &Config {
+                is_private: true,
+                allowed_sellers: vec![seller_address.clone()],
+                agreement_terms_hash: "mock-terms-hash".to_string(),
+                token_denom: token_denom.into(),
+                max_face_value_cents: Uint128::new(650000000),
+                min_face_value_cents: Uint128::new(500000),
+                tick_size: Uint128::new(1000),
+                dealers: vec![deps.api.addr_make("dealer-address")],
+                is_disabled: false,
+            },
+        )
+        .unwrap();
+
+        save_buyer_state(
+            &mut deps.storage,
+            &Buyer {
+                buyer_address: buyer_address.clone(),
+                has_accepted_pools: false,
+            },
+        )
+        .unwrap();
+
+        save_seller_state(
+            &mut deps.storage,
+            &Seller {
+                seller_address: seller_address.clone(),
+                accepted_value_cents: Uint128::new(1000000),
+                pool_denoms: vec![],
+                offer_hash: "mock-offer-hash".to_string(),
+            },
+        )
+        .unwrap();
+
+        match execute(deps.as_mut(), env.clone(), info, RemoveAsSeller {}) {
+            Ok(_) => {
+                panic!(
+                    "failed to detect error when removing a seller that has already accepted \
+                the contract"
+                )
+            }
+            Err(error) => match error {
+                ContractError::SellerAlreadyAccepted => {}
+                _ => {
+                    panic!(
+                        "Unexpected error encountered when attempting to remove a seller \
+                        that has already accepted the contract"
+                    )
+                }
+            },
+        }
+    }
+}

--- a/src/tests/instantiate/instantiate_tests.rs
+++ b/src/tests/instantiate/instantiate_tests.rs
@@ -6,19 +6,26 @@ mod instantiate_tests {
     use crate::query::contract_state::query_contract_state;
     use crate::storage::state_store::Config;
     use crate::version_info::{get_version_info, VersionInfoV1, CRATE_NAME, PACKAGE_VERSION};
-    use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Attribute};
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{Addr, Attribute, MessageInfo, Storage, Uint128};
     use provwasm_mocks::mock_provenance_dependencies;
 
     #[test]
     fn instantiate_private_forward_market_contract() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract-admin", &[]);
+        let buyer_address = deps.api.addr_make("contract-buyer");
+        let seller_address_0 = deps.api.addr_make("allowed-seller-0");
+        let seller_address_1 = deps.api.addr_make("allowed-seller-1");
+        let dealer_address = deps.api.addr_make("dealer-address");
+        let info = MessageInfo {
+            sender: buyer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         let instantiate_msg = InstantiateContractMsg {
             use_private_sellers: true,
             use_private_buyers: false,
-            allowed_sellers: vec!["allowed-seller-0".into(), "allowed-seller-1".into()],
+            allowed_sellers: vec![seller_address_0.clone().to_string(), seller_address_1.clone().to_string()],
             allowed_buyers: vec![],
             dealers: vec!["dealer-address".to_string()],
             max_buyer_count: 1,
@@ -29,12 +36,9 @@ mod instantiate_tests {
                 let expected_config_attributes = Config {
                     use_private_sellers: true,
                     use_private_buyers: false,
-                    allowed_sellers: vec![
-                        Addr::unchecked("allowed-seller-0"),
-                        Addr::unchecked("allowed-seller-1"),
-                    ],
+                    allowed_sellers: vec![seller_address_0.clone(), seller_address_1.clone()],
                     allowed_buyers: vec![],
-                    dealers: vec![Addr::unchecked("dealer-address")],
+                    dealers: vec![dealer_address.clone()],
                     is_disabled: false,
                     max_bid_count: 1,
                     contract_admin: Addr::unchecked("contract-admin"),
@@ -71,14 +75,21 @@ mod instantiate_tests {
     #[test]
     fn instantiate_invalid_seller_config() {
         let mut deps = mock_provenance_dependencies();
-        let info = mock_info("contract_buyer", &[]);
+        let buyer_address = deps.api.addr_make("contract-buyer");
+        let info = MessageInfo {
+            sender: buyer_address.clone(),
+            funds: vec![],
+        };
         let env = mock_env();
         let instantiate_msg = InstantiateContractMsg {
             use_private_sellers: false,
             use_private_buyers: false,
-            allowed_sellers: vec!["allowed-seller-0".into(), "allowed-seller-1".into()],
+            allowed_sellers: vec![
+                deps.api.addr_make("allowed-seller-0").to_string(),
+                deps.api.addr_make("allowed-seller-1").to_string(),
+            ],
             allowed_buyers: vec![],
-            dealers: vec!["dealer-address".to_string()],
+            dealers: vec![deps.api.addr_make("dealer-address").to_string()],
             max_buyer_count: 1,
         };
         let init_response = instantiate(deps.as_mut(), env, info, instantiate_msg);

--- a/src/util/helpers.rs
+++ b/src/util/helpers.rs
@@ -64,6 +64,9 @@ pub fn create_mint_tokens_messages(token_denom: String, token_count: Uint128, de
         allow_governance_control: true,
         allow_forced_transfer: false,
         required_attributes: vec![],
+        usd_cents: 0,
+        volume: 0,
+        usd_mills: 0,
     }));
 
     messages.push(CosmosMsg::from(MsgFinalizeRequest {
@@ -106,6 +109,7 @@ pub fn get_owned_scopes(
     let metadata_querier = MetadataQuerier::new(querier);
     metadata_querier.value_ownership(
         marker_address,
+        true,
         Some(PageRequest {
             key: vec![],
             offset,


### PR DESCRIPTION
Story details: https://app.shortcut.com/figure/story/321082/upgrade-fm-v2-contract-to-be-compatible-with-provenance-v1-19